### PR TITLE
Fix for Unknown Enum Value

### DIFF
--- a/lib/src/requests/request_builder.dart
+++ b/lib/src/requests/request_builder.dart
@@ -32,7 +32,7 @@ class TooManyRequestsException implements Exception {
   TooManyRequestsException(this._retryAfter);
 
   String toString() {
-    return "The rate limit for the requesting IP address is over its alloted limit.";
+    return "The rate limit for the requesting IP address is over its allotted limit.";
   }
 
   int get retryAfter => _retryAfter;
@@ -160,8 +160,6 @@ class ResponseHandler<T> {
   T handleResponse(final http.Response response) {
     // Too Many Requests
     if (response.statusCode == 429) {
-      print(response.headers);
-      print(response.headers["retry-after"]);
       int retryAfter = int.parse(response.headers["retry-after"]!);
       throw TooManyRequestsException(retryAfter);
     }

--- a/lib/src/requests/request_builder.dart
+++ b/lib/src/requests/request_builder.dart
@@ -161,7 +161,8 @@ class ResponseHandler<T> {
     // Too Many Requests
     if (response.statusCode == 429) {
       print(response.headers);
-      int retryAfter = int.parse(response.headers["Retry-After"]!);
+      print(response.headers["retry-after"]);
+      int retryAfter = int.parse(response.headers["retry-after"]!);
       throw TooManyRequestsException(retryAfter);
     }
 

--- a/lib/src/requests/request_builder.dart
+++ b/lib/src/requests/request_builder.dart
@@ -160,6 +160,7 @@ class ResponseHandler<T> {
   T handleResponse(final http.Response response) {
     // Too Many Requests
     if (response.statusCode == 429) {
+      print(response.headers);
       int retryAfter = int.parse(response.headers["Retry-After"]!);
       throw TooManyRequestsException(retryAfter);
     }

--- a/lib/src/xdr/xdr_other.dart
+++ b/lib/src/xdr/xdr_other.dart
@@ -20,17 +20,17 @@ class XdrClaimAtomType {
   get value => this._value;
 
   static const CLAIM_ATOM_TYPE_V0 = const XdrClaimAtomType._internal(0);
-  static const CLAIM_ATOM_TYPE_ORDER_BOOK = const XdrClaimAtomType._internal(2);
-  static const CLAIM_ATOM_TYPE_LIQUIDITY_POOL = const XdrClaimAtomType._internal(3);
+  static const CLAIM_ATOM_TYPE_ORDER_BOOK = const XdrClaimAtomType._internal(1);
+  static const CLAIM_ATOM_TYPE_LIQUIDITY_POOL = const XdrClaimAtomType._internal(2);
 
   static XdrClaimAtomType decode(XdrDataInputStream stream) {
     int value = stream.readInt();
     switch (value) {
       case 0:
         return CLAIM_ATOM_TYPE_V0;
-      case 2:
+      case 1:
         return CLAIM_ATOM_TYPE_ORDER_BOOK;
-      case 3:
+      case 2:
         return CLAIM_ATOM_TYPE_LIQUIDITY_POOL;
       default:
         throw Exception("Unknown enum value: $value");
@@ -55,11 +55,11 @@ class XdrClaimAtom {
 
   XdrClaimOfferAtom? _orderBook;
   XdrClaimOfferAtom? get orderBook => this._orderBook;
-  set orderBook(XdrClaimOfferAtom? value) => this._orderBook= value;
+  set orderBook(XdrClaimOfferAtom? value) => this._orderBook = value;
 
   XdrClaimLiquidityAtom? _liquidityPool;
   XdrClaimLiquidityAtom? get liquidityPool => this._liquidityPool;
-  set liquidityPool(XdrClaimLiquidityAtom? value) => this._liquidityPool= value;
+  set liquidityPool(XdrClaimLiquidityAtom? value) => this._liquidityPool = value;
 
   static void encode(XdrDataOutputStream stream, XdrClaimAtom encoded) {
     stream.writeInt(encoded.discriminant!.value);


### PR DESCRIPTION
After Protocol 18 upgrade, every successful Manage Offer & Path Payment operation will thrown `Unknown Enum Value` exception.
This PR fix that, and also correct the header for `TooManyRequestsException`.