### PR TITLE
Add missing `NaturalPersonKYCFields` field `proof_of_liveness` 

### DIFF
--- a/soroban.md
+++ b/soroban.md
@@ -374,7 +374,7 @@ SimulateTransactionResponse simulateResponse =
 
 The example above invokes this assembly script [auth contract](https://github.com/Soneso/as-soroban-examples/tree/main/auth#code).
 
-Other examples like [flutter atomic swap](https://github.com/Soneso/stellar_flutter_sdk/blob/master/test/soroban_test_auth.dart#L470) can be found in the [Soroban Auth Test Cases](https://github.com/Soneso/stellar_flutter_sdk/blob/master/test/soroban_test_auth.dart) of the SDK.
+Other examples like [flutter atomic swap](https://github.com/Soneso/stellar_flutter_sdk/blob/master/test/soroban_test_auth.dart#L467) can be found in the [Soroban Auth Test Cases](https://github.com/Soneso/stellar_flutter_sdk/blob/master/test/soroban_test_auth.dart) of the SDK.
 
 #### Get Events
 

--- a/test/soroban_test_auth.dart
+++ b/test/soroban_test_auth.dart
@@ -186,7 +186,6 @@ void main() {
           await sorobanServer.simulateTransaction(transaction);
       assert(simulateResponse.error == null);
       assert(simulateResponse.resultError == null);
-      ;
       assert(simulateResponse.footprint != null);
 
       // set footprint and sign
@@ -303,7 +302,6 @@ void main() {
           await sorobanServer.simulateTransaction(transaction);
       assert(simulateResponse.error == null);
       assert(simulateResponse.resultError == null);
-      ;
       assert(simulateResponse.footprint != null);
 
       // set footprint and sign
@@ -381,7 +379,6 @@ void main() {
           await sorobanServer.simulateTransaction(transaction);
       assert(simulateResponse.error == null);
       assert(simulateResponse.resultError == null);
-      ;
       assert(simulateResponse.footprint != null);
       assert(simulateResponse.contractAuth != null);
 


### PR DESCRIPTION
The `proof_of_liveness` field is mandatory in order to comply with the KYC requirements for SEP-6.