### PR TITLE
Fix url endpoint append

### DIFF
--- a/lib/src/sep/0006/transfer_server_service.dart
+++ b/lib/src/sep/0006/transfer_server_service.dart
@@ -26,7 +26,7 @@ class TransferServerService {
   /// [language] Language code specified using ISO 639-1. description fields in the response should be in this language. Defaults to en.
   /// [jwt] token previously received from the anchor via the SEP-10 authentication flow
   Future<InfoResponse?> info(String? language, String? jwt) async {
-    Uri serverURI = Uri.parse(_transferServiceAddress).resolve('info');
+    Uri serverURI = Util.appendEndpointToUrl(_transferServiceAddress, 'info');
 
     _InfoRequestBuilder requestBuilder = _InfoRequestBuilder(httpClient, serverURI);
 
@@ -49,7 +49,7 @@ class TransferServerService {
   /// additional information (if desired) that the user must submit via the /customer endpoint
   /// to be able to deposit.
   Future<DepositResponse?> deposit(DepositRequest request) async {
-    Uri serverURI = Uri.parse(_transferServiceAddress).resolve('deposit');
+    Uri serverURI = Util.appendEndpointToUrl(_transferServiceAddress, 'deposit');
 
     _DepositRequestBuilder requestBuilder = _DepositRequestBuilder(httpClient, serverURI);
 
@@ -106,7 +106,7 @@ class TransferServerService {
   }
 
   Future<WithdrawResponse?> withdraw(WithdrawRequest request) async {
-    Uri serverURI = Uri.parse(_transferServiceAddress).resolve('withdraw');
+    Uri serverURI = Util.appendEndpointToUrl(_transferServiceAddress, 'withdraw');
 
     _WithdrawRequestBuilder requestBuilder = _WithdrawRequestBuilder(httpClient, serverURI);
 
@@ -174,7 +174,7 @@ class TransferServerService {
   }
 
   Future<FeeResponse?> fee(FeeRequest request) async {
-    Uri serverURI = Uri.parse(_transferServiceAddress).resolve('fee');
+    Uri serverURI = Util.appendEndpointToUrl(_transferServiceAddress, 'fee');
 
     _FeeRequestBuilder requestBuilder = _FeeRequestBuilder(httpClient, serverURI);
 
@@ -198,7 +198,7 @@ class TransferServerService {
   /// With it, wallets can display the status of deposits and withdrawals while they process and a history of
   /// past transactions with the anchor. It's only for transactions that are deposits to or withdrawals from the anchor.
   Future<AnchorTransactionsResponse?> transactions(AnchorTransactionsRequest request) async {
-    Uri serverURI = Uri.parse(_transferServiceAddress).resolve('transactions');
+    Uri serverURI = Util.appendEndpointToUrl(_transferServiceAddress, 'transactions');
 
     _AnchorTransactionsRequestBuilder requestBuilder =
         _AnchorTransactionsRequestBuilder(httpClient, serverURI);
@@ -232,7 +232,7 @@ class TransferServerService {
 
   /// The transaction endpoint enables clients to query/validate a specific transaction at an anchor.
   Future<AnchorTransactionResponse?> transaction(AnchorTransactionRequest request) async {
-    Uri serverURI = Uri.parse(_transferServiceAddress).resolve('transaction');
+    Uri serverURI = Util.appendEndpointToUrl(_transferServiceAddress, 'transaction');
 
     _AnchorTransactionRequestBuilder requestBuilder =
         _AnchorTransactionRequestBuilder(httpClient, serverURI);
@@ -259,7 +259,7 @@ class TransferServerService {
 
     checkNotNull(request.id, "request.id cannot be null");
     checkNotNull(request.fields, "request.fields cannot be null");
-    Uri serverURI = Uri.parse(_transferServiceAddress).resolve('transactions/${request.id!}');
+    Uri serverURI = Util.appendEndpointToUrl(_transferServiceAddress, 'transactions/${request.id!}');
 
     _PatchTransactionRequestBuilder requestBuilder =
         _PatchTransactionRequestBuilder(httpClient, serverURI);

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -117,6 +117,32 @@ class Util {
 
     return base64Url.encode(values);
   }
+
+  /// Appends an [endpoint] to a [baseUrl] string in a way that handles the presence or absence of a trailing slash in the [baseUrl].
+  ///
+  /// The function ensures that the returned URL does not have a double slash "//" between the base URL and the endpoint.
+  ///
+  /// This method is particularly useful when working with base URLs returned from various API sources, where some may end with a trailing slash and some may not.
+  ///
+  /// Returns the resulting URL as a [Uri].
+  ///
+  /// Example:
+  /// ```dart
+  /// String serverUrl = "https://api.anchor.com/sep6";
+  /// String endpoint = "info";
+  /// Uri serverUri = Utils.appendEndpointToUrl(serverUrl, endpoint);
+  /// // finalUrl will be a Uri for "https://api.anchor.com/sep6/info"
+  /// ```
+  static Uri appendEndpointToUrl(String baseUrl, String endpoint) {
+    // Ensure there is no trailing slash
+    if (baseUrl.endsWith("/")) {
+      baseUrl = baseUrl.substring(0, baseUrl.length - 1);
+    }
+
+    // Now append the endpoint
+    String completeUrl = "$baseUrl/$endpoint";
+    return Uri.parse(completeUrl);
+  }
 }
 
 class Base32 {


### PR DESCRIPTION
## Description

This PR introduces a utility method, `appendEndpointToUrl`, in the `Utils` class. This method is a fix for the previously used `Uri.resolve` method, which led to improper URL formatting for some API endpoints.

The `appendEndpointToUrl` method assists in appending an endpoint to a base URL string. It handles the presence or absence of a trailing slash in the base URL, ensuring the returned URL does not have a double slash "//" between the base URL and the endpoint.

This utility function is particularly useful when working with base URLs returned from various Stellar anchor servers. Some of these URLs may end with a trailing slash, while others may not. 

## Changes

* Added `appendEndpointToUrl` utility method in `Util` class with appropriate documentation.
* Replaced instances of `Uri.resolve` method with the new utility method to prevent issues with URL formatting.

## Impact

This method will simplify and streamline URL endpoint appending throughout the SDK, improving readability and maintainability. It also resolves the issue with the previous implementation that led to improper URL formatting in some cases.
