### PR TITLE
Web Platform Detection & Dio Overrides

### DIFF
--- a/lib/platform/non-web.dart
+++ b/lib/platform/non-web.dart
@@ -1,0 +1,1 @@
+const bool kIsWeb = false;

--- a/lib/platform/web.dart
+++ b/lib/platform/web.dart
@@ -1,0 +1,1 @@
+const bool kIsWeb = true;

--- a/lib/src/xdr/xdr_data_io.dart
+++ b/lib/src/xdr/xdr_data_io.dart
@@ -7,7 +7,8 @@ import "dart:typed_data";
 import "dart:convert";
 import 'package:pointycastle/src/utils.dart';
 
-import "package:flutter/foundation.dart" show kIsWeb;
+import 'package:stellar_flutter_sdk/platform/non-web.dart'
+    if (dart.library.html) 'package:stellar_flutter_sdk/platform/web.dart';
 
 class DataInput {
   Uint8List? data;


### PR DESCRIPTION
#### Web Platform Detection
When I try to build a Dart CLI with Flutter Stellar SDK, an error occurs, telling me that we can't use `package:flutter/foundation.dart` because there's no singleton exist in Dart (something like that, I forgot the exact error).

Because we only use the `foundation.dart` to access `kIsWeb`, I created two stub files, [platform/non-web.dart](https://github.com/hasToDev/stellar_flutter_sdk/tree/fix-platform/lib/platform) and [platform/web.dart](https://github.com/hasToDev/stellar_flutter_sdk/tree/fix-platform/lib/platform), just to replace the web platform detection.
With the help of `dart.library.html`, we are able to detect the web platform without importing `foundation.dart`.

This is just my own workaround, if you have a better way, it would be better.

#### Dio Overrides
When I try to run the compiled Dart CLI inside Docker container, the call to Soroban server failed due to badCertificateCallback.
So I add the option for Dio overrides just in case someone need it later.