### PR TITLE
CLI Build Fix

### DIFF
--- a/lib/src/soroban/soroban_server.dart
+++ b/lib/src/soroban/soroban_server.dart
@@ -41,9 +41,9 @@ class SorobanServer {
 
   /// Dio HTTP Overrides
   /// enable overrides to handle badCertificateCallback.
-  /// available only for the Web platform.
+  /// available only for the non-Web platform.
   set httpOverrides(bool setOverrides) {
-    if (kIsWeb && setOverrides) {
+    if (!kIsWeb && setOverrides) {
       dio.Dio dioOverrides = dio.Dio();
       (dioOverrides.httpClientAdapter as IOHttpClientAdapter).onHttpClientCreate =
           (IO.HttpClient client) {

--- a/lib/src/xdr/xdr_data_io.dart
+++ b/lib/src/xdr/xdr_data_io.dart
@@ -7,7 +7,8 @@ import "dart:typed_data";
 import "dart:convert";
 import 'package:pointycastle/src/utils.dart';
 
-import "package:flutter/foundation.dart" show kIsWeb;
+import 'package:stellar_flutter_sdk/stub/non-web.dart'
+    if (dart.library.html) 'package:stellar_flutter_sdk/stub/web.dart';
 
 class DataInput {
   Uint8List? data;

--- a/lib/stub/non-web.dart
+++ b/lib/stub/non-web.dart
@@ -1,0 +1,4 @@
+// Stub file to to replace foundation.dart in detecting web and non-web platforms.
+// kIsWeb should be TRUE in web.dart and FALSE in non-web.dart
+
+const bool kIsWeb = false;

--- a/lib/stub/web.dart
+++ b/lib/stub/web.dart
@@ -1,0 +1,4 @@
+// Stub file to to replace foundation.dart in detecting web and non-web platforms.
+// kIsWeb should be TRUE in web.dart and FALSE in non-web.dart
+
+const bool kIsWeb = true;


### PR DESCRIPTION
#### Web Platform Detection
When I try to build a Dart CLI with Flutter Stellar SDK, an error occurs, telling me that we can't use `package:flutter/foundation.dart` because there's no singleton exist in Dart (something like that, I forgot the exact error).

Because we only use the `foundation.dart` to access `kIsWeb`, I created two stub files, [stub/non-web.dart](https://github.com/hasToDev/stellar_flutter_sdk/tree/cli-build-support/lib/stub/non-web.dart) and [stub/web.dart](https://github.com/hasToDev/stellar_flutter_sdk/tree/cli-build-support/lib/stub/web.dart), just to replace the web platform detection.
With the help of `dart.library.html`, we are able to detect the web platform without importing `foundation.dart`.

This is just my own workaround, if you have a better way, it would be better.

#### Dio Overrides
When I try to run the compiled Dart CLI inside Docker container, the call to Soroban server failed due to `badCertificateCallback`.
So I add the option for Dio overrides just in case someone need it later.