### PR TITLE
Make `RequestBuilder headers` unmodifiable to prevent reference issues

### DIFF
--- a/lib/src/requests/request_builder.dart
+++ b/lib/src/requests/request_builder.dart
@@ -64,10 +64,10 @@ abstract class RequestBuilder {
   late List<String> _segments;
   bool _segmentsAdded = false;
   late Map<String, String> queryParameters;
-  static final Map<String, String> headers = {
+  static final Map<String, String> headers = Map<String, String>.unmodifiable({
     "X-Client-Name": "stellar_flutter_sdk",
     "X-Client-Version": StellarSDK.versionNumber
-  };
+  });
 
   RequestBuilder(
       http.Client httpClient, Uri serverURI, List<String>? defaultSegment) {

--- a/lib/src/sep/0006/transfer_server_service.dart
+++ b/lib/src/sep/0006/transfer_server_service.dart
@@ -721,10 +721,11 @@ class _DepositRequestBuilder extends RequestBuilder {
     ResponseHandler<DepositResponse> responseHandler =
         ResponseHandler<DepositResponse>(type);
 
-    final Map<String, String> depositHeaders = RequestBuilder.headers;
-    if (jwt != null) {
-      depositHeaders["Authorization"] = "Bearer $jwt";
-    }
+    final Map<String, String> depositHeaders = {
+      ...RequestBuilder.headers,
+      if (jwt != null) "Authorization": "Bearer $jwt",
+    };
+
     return await httpClient.get(uri, headers: depositHeaders).then((response) {
       return responseHandler.handleResponse(response);
     });
@@ -1275,10 +1276,10 @@ class _WithdrawRequestBuilder extends RequestBuilder {
     ResponseHandler<WithdrawResponse> responseHandler =
         ResponseHandler<WithdrawResponse>(type);
 
-    final Map<String, String> withdrawHeaders = RequestBuilder.headers;
-    if (jwt != null) {
-      withdrawHeaders["Authorization"] = "Bearer $jwt";
-    }
+    final Map<String, String> withdrawHeaders = {
+      ...RequestBuilder.headers,
+      if (jwt != null) "Authorization": "Bearer $jwt",
+    };
     return await httpClient.get(uri, headers: withdrawHeaders).then((response) {
       return responseHandler.handleResponse(response);
     });
@@ -1704,10 +1705,10 @@ class _InfoRequestBuilder extends RequestBuilder {
     ResponseHandler<InfoResponse> responseHandler =
         ResponseHandler<InfoResponse>(type);
 
-    final Map<String, String> infoHeaders = RequestBuilder.headers;
-    if (jwt != null) {
-      infoHeaders["Authorization"] = "Bearer $jwt";
-    }
+    final Map<String, String> infoHeaders = {
+      ...RequestBuilder.headers,
+      if (jwt != null) "Authorization": "Bearer $jwt",
+    };
     return await httpClient.get(uri, headers: infoHeaders).then((response) {
       return responseHandler.handleResponse(response);
     });
@@ -1772,10 +1773,10 @@ class _FeeRequestBuilder extends RequestBuilder {
     ResponseHandler<FeeResponse> responseHandler =
         ResponseHandler<FeeResponse>(type);
 
-    final Map<String, String> feeHeaders = RequestBuilder.headers;
-    if (jwt != null) {
-      feeHeaders["Authorization"] = "Bearer $jwt";
-    }
+    final Map<String, String> feeHeaders = {
+      ...RequestBuilder.headers,
+      if (jwt != null) "Authorization": "Bearer $jwt",
+    };
     return await httpClient.get(uri, headers: feeHeaders).then((response) {
       return responseHandler.handleResponse(response);
     });
@@ -2207,10 +2208,10 @@ class _AnchorTransactionsRequestBuilder extends RequestBuilder {
     ResponseHandler<AnchorTransactionsResponse> responseHandler =
         ResponseHandler<AnchorTransactionsResponse>(type);
 
-    final Map<String, String> atHeaders = RequestBuilder.headers;
-    if (jwt != null) {
-      atHeaders["Authorization"] = "Bearer $jwt";
-    }
+    final Map<String, String> atHeaders = {
+      ...RequestBuilder.headers,
+      if (jwt != null) "Authorization": "Bearer $jwt",
+    };
     return await httpClient.get(uri, headers: atHeaders).then((response) {
       return responseHandler.handleResponse(response);
     });
@@ -2277,10 +2278,10 @@ class _AnchorTransactionRequestBuilder extends RequestBuilder {
     ResponseHandler<AnchorTransactionResponse> responseHandler =
         ResponseHandler<AnchorTransactionResponse>(type);
 
-    final Map<String, String> atHeaders = RequestBuilder.headers;
-    if (jwt != null) {
-      atHeaders["Authorization"] = "Bearer $jwt";
-    }
+    final Map<String, String> atHeaders = {
+      ...RequestBuilder.headers,
+      if (jwt != null) "Authorization": "Bearer $jwt",
+    };
     return await httpClient.get(uri, headers: atHeaders).then((response) {
       return responseHandler.handleResponse(response);
     });
@@ -2320,10 +2321,10 @@ class _PatchTransactionRequestBuilder extends RequestBuilder {
 
   static Future<http.Response> requestExecute(http.Client httpClient, Uri uri,
       Map<String, dynamic> fields, String? jwt) async {
-    final Map<String, String> atHeaders = RequestBuilder.headers;
-    if (jwt != null) {
-      atHeaders["Authorization"] = "Bearer $jwt";
-    }
+    final Map<String, String> atHeaders = {
+      ...RequestBuilder.headers,
+      if (jwt != null) "Authorization": "Bearer $jwt",
+    };
     return await httpClient.patch(uri,
         body: {"transaction": json.encode(fields)}, headers: atHeaders);
   }

--- a/lib/src/sep/0012/kyc_service.dart
+++ b/lib/src/sep/0012/kyc_service.dart
@@ -440,10 +440,10 @@ class _PutCustomerInfoRequestBuilder extends RequestBuilder {
     ResponseHandler<PutCustomerInfoResponse> responseHandler =
         ResponseHandler<PutCustomerInfoResponse>(type);
 
-    final Map<String, String> hHeaders = RequestBuilder.headers;
-    if (jwt != null) {
-      hHeaders["Authorization"] = "Bearer $jwt";
-    }
+    final Map<String, String> hHeaders = {
+      ...RequestBuilder.headers,
+      if (jwt != null) "Authorization": "Bearer $jwt",
+    };
     var request = http.MultipartRequest('PUT', uri);
     request.headers.addAll(hHeaders);
     if (fields != null) {
@@ -495,10 +495,10 @@ class _PutCustomerVerificationRequestBuilder extends RequestBuilder {
     ResponseHandler<GetCustomerInfoResponse> responseHandler =
         ResponseHandler<GetCustomerInfoResponse>(type);
 
-    final Map<String, String> hHeaders = RequestBuilder.headers;
-    if (jwt != null) {
-      hHeaders["Authorization"] = "Bearer $jwt";
-    }
+    final Map<String, String> hHeaders = {
+      ...RequestBuilder.headers,
+      if (jwt != null) "Authorization": "Bearer $jwt",
+    };
     var request = http.MultipartRequest('PUT', uri);
     request.headers.addAll(hHeaders);
 
@@ -531,10 +531,10 @@ class _DeleteCustomerRequestBuilder extends RequestBuilder {
 
   static Future<http.Response> requestExecute(
       http.Client httpClient, Uri uri, Map<String, String>? fields, String? jwt) async {
-    final Map<String, String> hHeaders = RequestBuilder.headers;
-    if (jwt != null) {
-      hHeaders["Authorization"] = "Bearer $jwt";
-    }
+    final Map<String, String> hHeaders = {
+      ...RequestBuilder.headers,
+      if (jwt != null) "Authorization": "Bearer $jwt",
+    };
     var request = http.MultipartRequest('DELETE', uri);
     request.headers.addAll(hHeaders);
 
@@ -589,10 +589,10 @@ class _PutCustomerCallbackRequestBuilder extends RequestBuilder {
 
   static Future<http.Response> requestExecute(
       http.Client httpClient, Uri uri, Map<String, String>? fields, String? jwt) async {
-    final Map<String, String> hHeaders = RequestBuilder.headers;
-    if (jwt != null) {
-      hHeaders["Authorization"] = "Bearer $jwt";
-    }
+    final Map<String, String> hHeaders = {
+      ...RequestBuilder.headers,
+      if (jwt != null) "Authorization": "Bearer $jwt",
+    };
     var request = http.MultipartRequest('PUT', uri);
     request.headers.addAll(hHeaders);
 

--- a/lib/src/sep/0024/sep24_service.dart
+++ b/lib/src/sep/0024/sep24_service.dart
@@ -584,7 +584,7 @@ class _InfoRequestBuilder extends RequestBuilder {
     ResponseHandler<SEP24InfoResponse> responseHandler =
         ResponseHandler<SEP24InfoResponse>(type);
 
-    final Map<String, String> infoHeaders = RequestBuilder.headers;
+    final Map<String, String> infoHeaders = {...RequestBuilder.headers};
     return await httpClient.get(uri, headers: infoHeaders).then((response) {
       return responseHandler.handleResponse(response);
     });
@@ -640,10 +640,10 @@ class _FeeRequestBuilder extends RequestBuilder {
     ResponseHandler<SEP24FeeResponse> responseHandler =
         ResponseHandler<SEP24FeeResponse>(type);
 
-    final Map<String, String> feeHeaders = RequestBuilder.headers;
-    if (jwt != null) {
-      feeHeaders["Authorization"] = "Bearer $jwt";
-    }
+    final Map<String, String> feeHeaders = {
+      ...RequestBuilder.headers,
+      if (jwt != null) "Authorization": "Bearer $jwt",
+    };
 
     return await httpClient.get(uri, headers: feeHeaders).then((response) {
       return responseHandler.handleResponse(response);
@@ -764,8 +764,10 @@ class _PostRequestBuilder extends RequestBuilder {
     ResponseHandler<SEP24InteractiveResponse> responseHandler =
         ResponseHandler<SEP24InteractiveResponse>(type);
 
-    final Map<String, String> hHeaders = RequestBuilder.headers;
-    hHeaders["Authorization"] = "Bearer $jwt";
+    final Map<String, String> hHeaders = {
+      ...RequestBuilder.headers,
+      "Authorization": "Bearer $jwt",
+    };
     var request = http.MultipartRequest('POST', uri);
     request.headers.addAll(hHeaders);
     if (fields != null) {
@@ -1093,8 +1095,10 @@ class _AnchorTransactionsRequestBuilder extends RequestBuilder {
     ResponseHandler<SEP24TransactionsResponse> responseHandler =
         ResponseHandler<SEP24TransactionsResponse>(type);
 
-    final Map<String, String> atHeaders = RequestBuilder.headers;
-    atHeaders["Authorization"] = "Bearer $jwt";
+    final Map<String, String> atHeaders = {
+      ...RequestBuilder.headers,
+      "Authorization": "Bearer $jwt",
+    };
     return await httpClient.get(uri, headers: atHeaders).then((response) {
       return responseHandler.handleResponse(response);
     });
@@ -1199,8 +1203,10 @@ class _AnchorTransactionRequestBuilder extends RequestBuilder {
     ResponseHandler<SEP24TransactionResponse> responseHandler =
         ResponseHandler<SEP24TransactionResponse>(type);
 
-    final Map<String, String> atHeaders = RequestBuilder.headers;
-    atHeaders["Authorization"] = "Bearer $jwt";
+    final Map<String, String> atHeaders = {
+      ...RequestBuilder.headers,
+      "Authorization": "Bearer $jwt",
+    };
     return await httpClient.get(uri, headers: atHeaders).then((response) {
       return responseHandler.handleResponse(response);
     });


### PR DESCRIPTION
Fixes issue #98 