### PR TITLE
Forwarded http client to EventSource

### DIFF
--- a/lib/src/requests/accounts_request_builder.dart
+++ b/lib/src/requests/accounts_request_builder.dart
@@ -109,7 +109,10 @@ class AccountsRequestBuilder extends RequestBuilder {
         return;
       }
       source?.close();
-      source = await EventSource.connect(this.buildUri());
+      source = await EventSource.connect(
+        this.buildUri(),
+        client: httpClient,
+      );
       source!.listen((Event event) async {
         if (cancelled) {
           return null;

--- a/lib/src/requests/effects_request_builder.dart
+++ b/lib/src/requests/effects_request_builder.dart
@@ -82,7 +82,10 @@ class EffectsRequestBuilder extends RequestBuilder {
         return;
       }
       source?.close();
-      source = await EventSource.connect(this.buildUri());
+      source = await EventSource.connect(
+        this.buildUri(),
+        client: httpClient,
+      );
       source!.listen((Event event) async {
         if (cancelled) {
           return null;

--- a/lib/src/requests/ledgers_request_builder.dart
+++ b/lib/src/requests/ledgers_request_builder.dart
@@ -71,7 +71,10 @@ class LedgersRequestBuilder extends RequestBuilder {
         return;
       }
       source?.close();
-      source = await EventSource.connect(this.buildUri());
+      source = await EventSource.connect(
+        this.buildUri(),
+        client: httpClient,
+      );
       source!.listen((Event event) async {
         if (cancelled) {
           return null;

--- a/lib/src/requests/offers_request_builder.dart
+++ b/lib/src/requests/offers_request_builder.dart
@@ -119,7 +119,10 @@ class OffersRequestBuilder extends RequestBuilder {
         return;
       }
       source?.close();
-      source = await EventSource.connect(this.buildUri());
+      source = await EventSource.connect(
+        this.buildUri(),
+        client: httpClient,
+      );
       source!.listen((Event event) async {
         if (cancelled) {
           return null;

--- a/lib/src/requests/operations_request_builder.dart
+++ b/lib/src/requests/operations_request_builder.dart
@@ -113,7 +113,10 @@ class OperationsRequestBuilder extends RequestBuilder {
         return;
       }
       source?.close();
-      source = await EventSource.connect(this.buildUri());
+      source = await EventSource.connect(
+        this.buildUri(),
+        client: httpClient,
+      );
       source!.listen((Event event) async {
         if (cancelled) {
           return null;

--- a/lib/src/requests/order_book_request_builder.dart
+++ b/lib/src/requests/order_book_request_builder.dart
@@ -77,7 +77,10 @@ class OrderBookRequestBuilder extends RequestBuilder {
         return;
       }
       source?.close();
-      source = await EventSource.connect(this.buildUri());
+      source = await EventSource.connect(
+        this.buildUri(),
+        client: httpClient,
+      );
       source!.listen((Event event) async {
         if (cancelled) {
           return null;

--- a/lib/src/requests/payments_request_builder.dart
+++ b/lib/src/requests/payments_request_builder.dart
@@ -72,7 +72,10 @@ class PaymentsRequestBuilder extends RequestBuilder {
         return;
       }
       source?.close();
-      source = await EventSource.connect(this.buildUri());
+      source = await EventSource.connect(
+        this.buildUri(),
+        client: httpClient,
+      );
       source!.listen((Event event) async {
         if (cancelled) {
           return null;

--- a/lib/src/requests/trades_request_builder.dart
+++ b/lib/src/requests/trades_request_builder.dart
@@ -116,7 +116,10 @@ class TradesRequestBuilder extends RequestBuilder {
         return;
       }
       source?.close();
-      source = await EventSource.connect(this.buildUri());
+      source = await EventSource.connect(
+        this.buildUri(),
+        client: httpClient,
+      );
       source!.listen((Event event) async {
         if (cancelled) {
           return null;

--- a/lib/src/requests/transactions_request_builder.dart
+++ b/lib/src/requests/transactions_request_builder.dart
@@ -105,7 +105,10 @@ class TransactionsRequestBuilder extends RequestBuilder {
         return;
       }
       source?.close();
-      source = await EventSource.connect(this.buildUri());
+      source = await EventSource.connect(
+        this.buildUri(),
+        client: httpClient,
+      );
       source!.listen((Event event) async {
         if (cancelled) {
           return null;


### PR DESCRIPTION
We need this otherwise we get a unauthorised exception if we use this functionality with BlockDaemon. It will otherwise not use the JWT we configure in the StellarSDK instance.