### PR TITLE
chore: toml dep upgrade

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   fixnum: ^1.1.1
   http: ^1.5.0
   collection: ^1.18.0
-  toml: ^0.16.0
+  toml: ^0.17.0
   pointycastle: ^4.0.0
   unorm_dart: ^0.3.1+1
   decimal: ^3.2.4


### PR DESCRIPTION
Fix for this problem:

```
flutter pub get                                      
Resolving dependencies... (10.0s)
Because melos >=7.2.0 depends on xml ^6.6.1 which depends on petitparser ^7.0.0, melos >=7.2.0 requires petitparser ^7.0.0.
And because every version of stellar_flutter_sdk from git depends on toml ^0.16.0 which depends on petitparser ^6.0.2, melos >=7.2.0 is incompatible with stellar_flutter_sdk from git.
So, because beans_core depends on stellar_flutter_sdk from git and _ depends on melos 7.3.0, version solving failed.
Failed to update packages.
```