### PR TITLE
Add SEP-53 message signing and verification support 

### DIFF
--- a/doc/sep-0053.md
+++ b/doc/sep-0053.md
@@ -1,0 +1,215 @@
+# SEP-53: Sign and Verify Messages
+
+## Introduction
+
+SEP-53 standardizes the signing and verification of arbitrary messages using Stellar Ed25519 keypairs. This enables proof-of-ownership scenarios, off-chain authentication, and cross-chain dApp integrations without requiring on-chain transactions.
+
+## Quick Start
+
+```dart
+import 'package:stellar_flutter_sdk/stellar_flutter_sdk.dart';
+import 'dart:typed_data';
+
+void main() {
+  // Generate or restore a keypair
+  KeyPair keyPair = KeyPair.fromSecretSeed('SXXX...');
+
+  // Sign a message
+  Uint8List signature = keyPair.signMessageString('Hello, Stellar!');
+
+  // Verify the signature
+  bool isValid = keyPair.verifyMessageString('Hello, Stellar!', signature);
+  print('Signature valid: $isValid'); // true
+}
+```
+
+## API Reference
+
+### signMessage
+
+```dart
+Uint8List signMessage(Uint8List message)
+```
+
+Signs binary message data according to SEP-53.
+
+**Parameters:**
+- `message` (Uint8List): Raw bytes of the message to sign
+
+**Returns:** 64-byte Ed25519 signature as `Uint8List`
+
+**Throws:** Exception if the keypair does not contain a private key
+
+**Example:**
+```dart
+Uint8List messageBytes = Uint8List.fromList([1, 2, 3, 4]);
+Uint8List signature = keyPair.signMessage(messageBytes);
+
+// To transmit the signature as a string:
+String base64Sig = base64.encode(signature);  // base64 encoding
+String hexSig = Util.bytesToHex(signature);   // hex encoding
+```
+
+### signMessageString
+
+```dart
+Uint8List signMessageString(String message)
+```
+
+Signs a UTF-8 string message according to SEP-53.
+
+**Parameters:**
+- `message` (String): The string message to sign (UTF-8 encoded)
+
+**Returns:** 64-byte Ed25519 signature as `Uint8List`
+
+**Throws:** Exception if the keypair does not contain a private key
+
+**Example:**
+```dart
+Uint8List signature = keyPair.signMessageString('Authenticate me');
+
+// To transmit the signature as a string:
+String base64Sig = base64.encode(signature);  // base64 encoding
+String hexSig = Util.bytesToHex(signature);   // hex encoding
+```
+
+### verifyMessage
+
+```dart
+bool verifyMessage(Uint8List message, Uint8List signature)
+```
+
+Verifies a binary message signature according to SEP-53.
+
+**Parameters:**
+- `message` (Uint8List): Original message bytes
+- `signature` (Uint8List): 64-byte Ed25519 signature to verify. If the signature was received as a string, decode it first (see example below).
+
+**Returns:** `true` if valid, `false` otherwise (does not throw on failure)
+
+**Example:**
+```dart
+// If the signature was received as base64 or hex string:
+Uint8List signature = base64.decode(base64SignatureString);
+// or: Uint8List signature = Util.hexToBytes(hexSignatureString);
+
+Uint8List messageBytes = Uint8List.fromList([1, 2, 3, 4]);
+bool isValid = keyPair.verifyMessage(messageBytes, signature);
+```
+
+### verifyMessageString
+
+```dart
+bool verifyMessageString(String message, Uint8List signature)
+```
+
+Verifies a UTF-8 string message signature according to SEP-53.
+
+**Parameters:**
+- `message` (String): Original string message (UTF-8 encoded)
+- `signature` (Uint8List): 64-byte Ed25519 signature to verify. If the signature was received as a string, decode it first (see example below).
+
+**Returns:** `true` if valid, `false` otherwise (does not throw on failure)
+
+**Example:**
+```dart
+// If the signature was received as base64 or hex string:
+Uint8List signature = base64.decode(base64SignatureString);
+// or: Uint8List signature = Util.hexToBytes(hexSignatureString);
+
+bool isValid = keyPair.verifyMessageString('Authenticate me', signature);
+```
+
+## Detailed Usage
+
+### Signing Binary Data
+
+```dart
+import 'dart:convert';
+import 'dart:typed_data';
+
+Map<String, dynamic> jsonData = {'timestamp': 1234567890, 'action': 'login'};
+Uint8List messageBytes = Uint8List.fromList(utf8.encode(jsonEncode(jsonData)));
+
+Uint8List signature = signer.signMessage(messageBytes);
+```
+
+### Verifying a Message
+
+```dart
+import 'dart:convert';
+
+// Create a verification-only keypair from account ID
+KeyPair verifier = KeyPair.fromAccountId('GXXX...');
+
+// Decode the signature received from the signer
+Uint8List signature = base64.decode(receivedBase64Signature);
+// or: Uint8List signature = Util.hexToBytes(receivedHexSignature);
+
+String message = 'Authenticate me';
+if (verifier.verifyMessageString(message, signature)) {
+  print('Signature is valid');
+} else {
+  print('Signature verification failed');
+}
+```
+
+### Handling Verification Failure
+
+```dart
+// Verification returns false instead of throwing exceptions
+bool result = keyPair.verifyMessageString('Original message', signature);
+
+if (!result) {
+  // Handle invalid signature
+  // Possible reasons: wrong message, wrong public key, malformed signature
+  print('Signature verification failed');
+}
+```
+
+## Protocol Details
+
+SEP-53 defines the following signing procedure:
+
+1. **Prefix:** The message is prepended with `"Stellar Signed Message:\n"` (UTF-8 bytes)
+2. **Hash:** The concatenated payload is hashed using SHA-256
+3. **Sign:** The hash is signed using Ed25519 with the private key
+
+```
+signature = ed25519_sign(privateKey, SHA256("Stellar Signed Message:\n" + message))
+```
+
+The prefix provides domain separation, ensuring that message signatures cannot be confused with transaction signatures.
+
+## Security Notes
+
+- **Domain Separation:** The `"Stellar Signed Message:\n"` prefix prevents signed messages from being misinterpreted as transaction signatures.
+- **Key Ownership vs Account Control:** A valid signature proves key ownership but does not necessarily mean control over an account (multi-signature accounts may require additional signers).
+- **User Confirmation:** Applications should always display the full message content to users before signing to prevent phishing attacks.
+- **Check Signing Capability:** Use `canSign()` before calling sign methods to ensure the keypair contains a private key.
+- **Never Sign Blindly:** Do not sign arbitrary data from untrusted sources.
+
+## Interoperability
+
+Signatures produced by this SDK are compatible with other Stellar SDKs implementing SEP-53:
+
+- Java SDK: `KeyPair.signMessage()` / `KeyPair.verifyMessage()`
+- Python SDK: `Keypair.sign_message()` / `Keypair.verify_message()`
+
+Example cross-SDK verification:
+
+```dart
+import 'dart:convert';
+
+// Message signed by another SDK, received as base64 string
+KeyPair verifier = KeyPair.fromAccountId('GXXX...');
+Uint8List signature = base64.decode(signatureFromOtherSdk);
+
+bool isValid = verifier.verifyMessageString('Cross-SDK message', signature);
+```
+
+## References
+
+- [SEP-53 Specification](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0053.md)
+- [Stellar Developer Documentation](https://developers.stellar.org)


### PR DESCRIPTION
## Summary

- Implement SEP-53 (Sign and Verify Messages) on `KeyPair` with four public methods: `signMessage`, `signMessageString`, `verifyMessage`, `verifyMessageString`
- Add unit tests covering all spec test vectors, base64/hex encoding round-trips, failure cases, and edge cases
- Add API and usage documentation in `doc/sep-0053.md`
- Signatures match all three SEP-53 spec test vectors (ASCII, Japanese, binary)
- Cross-SDK interoperability: signatures are compatible with Java and Python SDK implementations
- No breaking changes to existing API