### PR TITLE
Fix SEP-0011 MEMO_TEXT escaping to use C-style \xNN UTF-8 byte format

### DIFF
--- a/lib/src/sep/0011/txrep.dart
+++ b/lib/src/sep/0011/txrep.dart
@@ -104,9 +104,8 @@ class TxRep {
     // Preconditions — delegate to generated code.
     tx.cond.toTxRep('$prefix.cond', lines);
 
-    // Memo — handle manually because the facade uses jsonEncode/jsonDecode
-    // for legacy format compatibility, while generated code uses
-    // TxRepHelper.escapeString which emits \xNN hex escapes.
+    // Memo — handle manually so the decode side can accept both the SEP-0011
+    // \xNN format and legacy \uNNNN JSON escapes from older SDK versions.
     _encodeMemo(tx.memo, lines, '$prefix.memo');
 
     // Operations.
@@ -238,8 +237,7 @@ class TxRep {
       case XdrMemoType.MEMO_NONE:
         break;
       case XdrMemoType.MEMO_TEXT:
-        // Use JSON encoding for compatibility with the legacy format.
-        lines.add('$prefix.text: ${jsonEncode(memo.text)}');
+        lines.add('$prefix.text: ${TxRepHelper.escapeString(memo.text!)}');
         break;
       case XdrMemoType.MEMO_ID:
         memo.id!.toTxRep('$prefix.id', lines);
@@ -361,10 +359,33 @@ class TxRep {
     } else if (memoTypeStr == 'MEMO_TEXT') {
       String? textStr = TxRepHelper.getValue(map, '$prefix.text');
       if (textStr == null) throw Exception('missing $prefix.text');
-      // Decode JSON-encoded string (reverses jsonEncode() in encode).
+      // Per SEP-0011, MEMO_TEXT uses C-style \xNN UTF-8 byte escapes.
+      // For backwards compatibility, also accept legacy \uNNNN JSON escapes
+      // produced by older versions of this SDK.
       String text;
-      if (textStr.startsWith('"') && textStr.endsWith('"')) {
-        text = jsonDecode(textStr) as String;
+      if (textStr.startsWith('"') &&
+          textStr.endsWith('"') &&
+          textStr.length >= 2) {
+        // Detect an unescaped \uNNNN sequence: a \u preceded by an even
+        // number of backslashes (zero or more pairs). An odd count means the
+        // preceding backslash escapes the \u, which is literal text and
+        // should be handled by the SEP-0011 unescaper.
+        final legacyUnicode = RegExp(r'(?<!\\)(?:\\\\)*\\u[0-9a-fA-F]{4}');
+        if (legacyUnicode.hasMatch(textStr)) {
+          try {
+            text = jsonDecode(textStr) as String;
+          } on FormatException catch (e) {
+            throw Exception(
+              'invalid $prefix.text (legacy \\uNNNN form): ${e.message}',
+            );
+          }
+        } else {
+          try {
+            text = TxRepHelper.unescapeString(textStr);
+          } on FormatException catch (e) {
+            throw Exception('invalid $prefix.text: ${e.message}');
+          }
+        }
       } else {
         text = textStr;
       }

--- a/lib/src/xdr/txrep_helper.dart
+++ b/lib/src/xdr/txrep_helper.dart
@@ -127,8 +127,9 @@ class TxRepHelper {
 
   /// Escape a string for TxRep double-quoted format.
   ///
-  /// Escapes `"`, `\`, represents `\n` as `\\n`, and encodes non-ASCII bytes
-  /// (outside 0x20–0x7e) as `\\xNN`.
+  /// Escapes `"`, `\`, represents `\n`, `\r`, `\t` as their C-style short
+  /// escapes, and encodes any other non-printable or non-ASCII bytes as
+  /// `\xNN` per UTF-8 byte. Matches the stc reference and the iOS/PHP SDKs.
   static String escapeString(String s) {
     StringBuffer buf = StringBuffer();
     buf.write('"');
@@ -142,6 +143,12 @@ class TxRepHelper {
       } else if (rune == 0x0A) {
         // newline
         buf.write(r'\n');
+      } else if (rune == 0x0D) {
+        // carriage return
+        buf.write(r'\r');
+      } else if (rune == 0x09) {
+        // tab
+        buf.write(r'\t');
       } else if (rune >= 0x20 && rune <= 0x7E) {
         buf.writeCharCode(rune);
       } else {
@@ -159,8 +166,8 @@ class TxRepHelper {
 
   /// Unescape a TxRep string value.
   ///
-  /// Handles `\"`, `\\`, `\n`, and `\xNN` escape sequences. If the input is
-  /// enclosed in double quotes, they are stripped.
+  /// Handles `\"`, `\\`, `\n`, `\r`, `\t`, and `\xNN` escape sequences. If the
+  /// input is enclosed in double quotes, they are stripped.
   static String unescapeString(String s) {
     String input = s;
     if (input.startsWith('"') && input.endsWith('"') && input.length >= 2) {
@@ -192,6 +199,14 @@ class TxRepHelper {
         } else if (next == 'n') {
           flushPendingBytes();
           buf.write('\n');
+          i += 2;
+        } else if (next == 'r') {
+          flushPendingBytes();
+          buf.write('\r');
+          i += 2;
+        } else if (next == 't') {
+          flushPendingBytes();
+          buf.write('\t');
           i += 2;
         } else if (next == 'x' && i + 3 < input.length) {
           String hexStr = input.substring(i + 2, i + 4);

--- a/test/unit/sep/txrep_test.dart
+++ b/test/unit/sep/txrep_test.dart
@@ -589,6 +589,147 @@ void main() {
       expect(reconstructedXdr, equals(xdr));
     });
 
+    test('MEMO_TEXT with non-ASCII uses SEP-0011 \\xNN UTF-8 byte escaping', () {
+      final paymentOp = PaymentOperationBuilder(
+        destinationKeyPair.accountId,
+        Asset.NATIVE,
+        "100.0"
+      ).build();
+
+      final transaction = TransactionBuilder(sourceAccount)
+        .addOperation(paymentOp)
+        .addMemo(Memo.text("café"))
+        .build();
+
+      transaction.sign(sourceKeyPair, testNetwork);
+
+      final xdr = transaction.toEnvelopeXdrBase64();
+      final txRep = TxRep.fromTransactionEnvelopeXdrBase64(xdr);
+
+      // Per SEP-0011, U+00E9 (é) is encoded as its UTF-8 bytes 0xC3 0xA9
+      // using \xNN escapes, not as the JSON \u00e9 form.
+      expect(txRep, contains(r'tx.memo.text: "caf\xc3\xa9"'));
+      expect(txRep, isNot(contains(r'\u00e9')));
+
+      // And it must round-trip back to the original XDR.
+      final reconstructedXdr =
+          TxRep.transactionEnvelopeXdrBase64FromTxRep(txRep);
+      expect(reconstructedXdr, equals(xdr));
+    });
+
+    test('MEMO_TEXT decode accepts legacy \\uNNNN JSON escapes', () {
+      // Build a reference envelope using the new \xNN encoding, then
+      // rewrite the memo line to use the legacy \u00e9 form that older
+      // versions of this SDK produced. Decoding must still succeed and
+      // yield the same XDR.
+      final paymentOp = PaymentOperationBuilder(
+        destinationKeyPair.accountId,
+        Asset.NATIVE,
+        "100.0"
+      ).build();
+
+      final transaction = TransactionBuilder(sourceAccount)
+        .addOperation(paymentOp)
+        .addMemo(Memo.text("café"))
+        .build();
+
+      transaction.sign(sourceKeyPair, testNetwork);
+
+      final xdr = transaction.toEnvelopeXdrBase64();
+      final txRep = TxRep.fromTransactionEnvelopeXdrBase64(xdr);
+      final legacyTxRep = txRep.replaceFirst(
+        r'tx.memo.text: "caf\xc3\xa9"',
+        r'tx.memo.text: "caf\u00e9"',
+      );
+      expect(legacyTxRep, isNot(equals(txRep)));
+
+      final reconstructedXdr =
+          TxRep.transactionEnvelopeXdrBase64FromTxRep(legacyTxRep);
+      expect(reconstructedXdr, equals(xdr));
+    });
+
+    // Helper: build a signed envelope carrying the given memo text and
+    // assert that TxRep encode/decode round-trips back to the same XDR.
+    String memoTextRoundTrip(String memoText) {
+      final paymentOp = PaymentOperationBuilder(
+        destinationKeyPair.accountId,
+        Asset.NATIVE,
+        "100.0",
+      ).build();
+
+      final transaction = TransactionBuilder(sourceAccount)
+        .addOperation(paymentOp)
+        .addMemo(Memo.text(memoText))
+        .build();
+
+      transaction.sign(sourceKeyPair, testNetwork);
+
+      final xdr = transaction.toEnvelopeXdrBase64();
+      final txRep = TxRep.fromTransactionEnvelopeXdrBase64(xdr);
+      final reconstructedXdr =
+          TxRep.transactionEnvelopeXdrBase64FromTxRep(txRep);
+      expect(reconstructedXdr, equals(xdr));
+      return txRep;
+    }
+
+    test('MEMO_TEXT with newline uses \\n short escape', () {
+      final txRep = memoTextRoundTrip('line1\nline2');
+      expect(txRep, contains(r'tx.memo.text: "line1\nline2"'));
+    });
+
+    test('MEMO_TEXT with 4-byte UTF-8 (emoji) encodes as four \\xNN bytes', () {
+      // U+1F680 ROCKET = F0 9F 9A 80
+      final txRep = memoTextRoundTrip('go \u{1F680}');
+      expect(txRep, contains(r'tx.memo.text: "go \xf0\x9f\x9a\x80"'));
+    });
+
+    test('MEMO_TEXT empty string round-trips', () {
+      final txRep = memoTextRoundTrip('');
+      expect(txRep, contains('tx.memo.text: ""'));
+    });
+
+    test('MEMO_TEXT containing literal backslash-u is not misrouted', () {
+      // The text contains the literal 2-char sequence \u (backslash + u).
+      // After SEP-0011 escaping the backslash doubles, so the encoded form
+      // contains \\u — the legacy-detection regex must NOT treat that as a
+      // \uNNNN escape, and decode must preserve the original text.
+      final txRep = memoTextRoundTrip(r'lit \user');
+      expect(txRep, contains(r'tx.memo.text: "lit \\user"'));
+    });
+
+    test('MEMO_TEXT at 28-byte UTF-8 boundary with multibyte chars', () {
+      // 14 x 'é' = 28 UTF-8 bytes (2 bytes each), the Stellar memo text limit.
+      final txRep = memoTextRoundTrip('é' * 14);
+      expect(txRep, contains(r'\xc3\xa9' * 14));
+    });
+
+    test('MEMO_TEXT legacy decode preserves embedded quote escapes', () {
+      final paymentOp = PaymentOperationBuilder(
+        destinationKeyPair.accountId,
+        Asset.NATIVE,
+        "100.0",
+      ).build();
+
+      final transaction = TransactionBuilder(sourceAccount)
+        .addOperation(paymentOp)
+        .addMemo(Memo.text('café "x"'))
+        .build();
+
+      transaction.sign(sourceKeyPair, testNetwork);
+
+      final xdr = transaction.toEnvelopeXdrBase64();
+      // Legacy form (older SDK output): JSON \uNNNN escapes plus \" for quotes.
+      final legacyTxRep = TxRep.fromTransactionEnvelopeXdrBase64(xdr)
+          .replaceFirst(
+            r'tx.memo.text: "caf\xc3\xa9 \"x\""',
+            r'tx.memo.text: "caf\u00e9 \"x\""',
+          );
+
+      final reconstructedXdr =
+          TxRep.transactionEnvelopeXdrBase64FromTxRep(legacyTxRep);
+      expect(reconstructedXdr, equals(xdr));
+    });
+
     test('round-trip: transaction with MEMO_ID', () {
       final paymentOp = PaymentOperationBuilder(
         destinationKeyPair.accountId,

--- a/test/unit/sep/txrep_test.dart
+++ b/test/unit/sep/txrep_test.dart
@@ -730,6 +730,289 @@ void main() {
       expect(reconstructedXdr, equals(xdr));
     });
 
+    test('MEMO_TEXT missing text field throws', () {
+      final paymentOp = PaymentOperationBuilder(
+        destinationKeyPair.accountId,
+        Asset.NATIVE,
+        "100.0",
+      ).build();
+
+      final transaction = TransactionBuilder(sourceAccount)
+        .addOperation(paymentOp)
+        .addMemo(Memo.text('hello'))
+        .build();
+
+      transaction.sign(sourceKeyPair, testNetwork);
+
+      final txRep = TxRep.fromTransactionEnvelopeXdrBase64(
+        transaction.toEnvelopeXdrBase64(),
+      );
+      // Drop the tx.memo.text line entirely.
+      final broken = txRep
+          .split('\n')
+          .where((l) => !l.startsWith('tx.memo.text:'))
+          .join('\n');
+
+      expect(
+        () => TxRep.transactionEnvelopeXdrBase64FromTxRep(broken),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('missing tx.memo.text'),
+          ),
+        ),
+      );
+    });
+
+    test('MEMO_TEXT malformed legacy \\uNNNN sequence throws', () {
+      final paymentOp = PaymentOperationBuilder(
+        destinationKeyPair.accountId,
+        Asset.NATIVE,
+        "100.0",
+      ).build();
+
+      final transaction = TransactionBuilder(sourceAccount)
+        .addOperation(paymentOp)
+        .addMemo(Memo.text('hello'))
+        .build();
+
+      transaction.sign(sourceKeyPair, testNetwork);
+
+      final txRep = TxRep.fromTransactionEnvelopeXdrBase64(
+        transaction.toEnvelopeXdrBase64(),
+      );
+      // Contains a valid-looking \u0041 (trips the legacy-unicode heuristic)
+      // followed by an invalid JSON escape \z, so jsonDecode throws and the
+      // facade rewraps the FormatException.
+      final broken = txRep.replaceFirst(
+        'tx.memo.text: "hello"',
+        r'tx.memo.text: "\u0041\z"',
+      );
+
+      expect(
+        () => TxRep.transactionEnvelopeXdrBase64FromTxRep(broken),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('invalid tx.memo.text (legacy'),
+          ),
+        ),
+      );
+    });
+
+    test('MEMO_TEXT malformed \\xNN UTF-8 sequence throws', () {
+      final paymentOp = PaymentOperationBuilder(
+        destinationKeyPair.accountId,
+        Asset.NATIVE,
+        "100.0",
+      ).build();
+
+      final transaction = TransactionBuilder(sourceAccount)
+        .addOperation(paymentOp)
+        .addMemo(Memo.text('hello'))
+        .build();
+
+      transaction.sign(sourceKeyPair, testNetwork);
+
+      final txRep = TxRep.fromTransactionEnvelopeXdrBase64(
+        transaction.toEnvelopeXdrBase64(),
+      );
+      // A lone 0xC3 is an incomplete UTF-8 sequence (0xC3 is a 2-byte
+      // lead byte); decoding must throw FormatException which the facade
+      // rewraps as a TxRep-style Exception.
+      final broken = txRep.replaceFirst(
+        'tx.memo.text: "hello"',
+        r'tx.memo.text: "\xc3"',
+      );
+
+      expect(
+        () => TxRep.transactionEnvelopeXdrBase64FromTxRep(broken),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('invalid tx.memo.text'),
+          ),
+        ),
+      );
+    });
+
+    test('encodes V0 envelope without time bounds', () {
+      // Build a V0 transaction envelope directly (legacy format).
+      final sourceBytes = StrKey.decodeStellarAccountId(sourceKeyPair.accountId);
+      final v0tx = XdrTransactionV0(
+        XdrUint256(sourceBytes),
+        XdrUint32(100),
+        XdrSequenceNumber(BigInt.from(1)),
+        null, // no time bounds → exercises PRECOND_NONE branch
+        XdrMemo(XdrMemoType.MEMO_NONE),
+        [],
+        XdrTransactionV0Ext(0),
+      );
+      final envelope =
+          XdrTransactionEnvelope(XdrEnvelopeType.ENVELOPE_TYPE_TX_V0)
+            ..v0 = XdrTransactionV0Envelope(v0tx, []);
+
+      final txRep =
+          TxRep.fromTransactionEnvelopeXdrBase64(envelope.toBase64EncodedXdrString());
+
+      expect(txRep, contains('type: ENVELOPE_TYPE_TX'));
+      expect(txRep, contains('tx.sourceAccount: ${sourceKeyPair.accountId}'));
+      expect(txRep, contains('tx.cond.type: PRECOND_NONE'));
+    });
+
+    test('encodes V0 envelope with time bounds', () {
+      final sourceBytes = StrKey.decodeStellarAccountId(sourceKeyPair.accountId);
+      final tb = XdrTimeBounds(
+        XdrUint64(BigInt.from(1000)),
+        XdrUint64(BigInt.from(2000)),
+      );
+      final v0tx = XdrTransactionV0(
+        XdrUint256(sourceBytes),
+        XdrUint32(100),
+        XdrSequenceNumber(BigInt.from(1)),
+        tb, // time bounds present → exercises PRECOND_TIME branch
+        XdrMemo(XdrMemoType.MEMO_NONE),
+        [],
+        XdrTransactionV0Ext(0),
+      );
+      final envelope =
+          XdrTransactionEnvelope(XdrEnvelopeType.ENVELOPE_TYPE_TX_V0)
+            ..v0 = XdrTransactionV0Envelope(v0tx, []);
+
+      final txRep =
+          TxRep.fromTransactionEnvelopeXdrBase64(envelope.toBase64EncodedXdrString());
+
+      expect(txRep, contains('tx.cond.type: PRECOND_TIME'));
+      expect(txRep, contains('tx.cond.timeBounds.minTime: 1000'));
+      expect(txRep, contains('tx.cond.timeBounds.maxTime: 2000'));
+    });
+
+    test('decodes legacy tx.timeBounds._present format', () {
+      // Hand-written TxRep using the legacy tx.timeBounds._present: true
+      // shape instead of tx.cond.
+      final txRep = [
+        'type: ENVELOPE_TYPE_TX',
+        'tx.sourceAccount: ${sourceKeyPair.accountId}',
+        'tx.fee: 100',
+        'tx.seqNum: 1',
+        'tx.timeBounds._present: true',
+        'tx.timeBounds.minTime: 1000',
+        'tx.timeBounds.maxTime: 2000',
+        'tx.memo.type: MEMO_NONE',
+        'tx.operations.len: 0',
+        'tx.ext.v: 0',
+        'signatures.len: 0',
+      ].join('\n');
+
+      final reconstructed = TxRep.transactionEnvelopeXdrBase64FromTxRep(txRep);
+      final envelope = XdrTransactionEnvelope.fromEnvelopeXdrString(
+        reconstructed,
+      );
+      expect(
+        envelope.v1!.tx.cond.discriminant,
+        equals(XdrPreconditionType.PRECOND_TIME),
+      );
+      expect(
+        envelope.v1!.tx.cond.timeBounds!.minTime.uint64,
+        equals(BigInt.from(1000)),
+      );
+      expect(
+        envelope.v1!.tx.cond.timeBounds!.maxTime.uint64,
+        equals(BigInt.from(2000)),
+      );
+    });
+
+    test('decode throws on missing type header', () {
+      final txRep = [
+        'tx.sourceAccount: ${sourceKeyPair.accountId}',
+        'tx.fee: 100',
+      ].join('\n');
+
+      expect(
+        () => TxRep.transactionEnvelopeXdrBase64FromTxRep(txRep),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('unsupported or missing TxRep type'),
+          ),
+        ),
+      );
+    });
+
+    test('decode throws on fee-bump inner type mismatch', () {
+      // Build a real fee-bump TxRep by round-tripping a fee-bump envelope,
+      // then flip the inner type to something unexpected.
+      final paymentOp = PaymentOperationBuilder(
+        destinationKeyPair.accountId,
+        Asset.NATIVE,
+        "100.0",
+      ).build();
+      final inner = TransactionBuilder(sourceAccount)
+        .addOperation(paymentOp)
+        .build();
+      inner.sign(sourceKeyPair, testNetwork);
+
+      final feeBump = FeeBumpTransactionBuilder(inner)
+        .setBaseFee(200)
+        .setFeeAccount(sourceKeyPair.accountId)
+        .build();
+      feeBump.sign(sourceKeyPair, testNetwork);
+
+      final txRep = TxRep.fromTransactionEnvelopeXdrBase64(
+        feeBump.toEnvelopeXdrBase64(),
+      );
+      final broken = txRep.replaceFirst(
+        'feeBump.tx.innerTx.type: ENVELOPE_TYPE_TX',
+        'feeBump.tx.innerTx.type: ENVELOPE_TYPE_TX_V0',
+      );
+
+      expect(
+        () => TxRep.transactionEnvelopeXdrBase64FromTxRep(broken),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('unexpected feeBump.tx.innerTx.type'),
+          ),
+        ),
+      );
+    });
+
+    test('decode throws on unknown memo type', () {
+      final paymentOp = PaymentOperationBuilder(
+        destinationKeyPair.accountId,
+        Asset.NATIVE,
+        "100.0",
+      ).build();
+      final transaction = TransactionBuilder(sourceAccount)
+        .addOperation(paymentOp)
+        .build();
+      transaction.sign(sourceKeyPair, testNetwork);
+
+      final txRep = TxRep.fromTransactionEnvelopeXdrBase64(
+        transaction.toEnvelopeXdrBase64(),
+      );
+      final broken = txRep.replaceFirst(
+        'tx.memo.type: MEMO_NONE',
+        'tx.memo.type: MEMO_BOGUS',
+      );
+
+      expect(
+        () => TxRep.transactionEnvelopeXdrBase64FromTxRep(broken),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('unknown memo type: MEMO_BOGUS'),
+          ),
+        ),
+      );
+    });
+
     test('round-trip: transaction with MEMO_ID', () {
       final paymentOp = PaymentOperationBuilder(
         destinationKeyPair.accountId,

--- a/test/unit/xdr/txrep_helper_test.dart
+++ b/test/unit/xdr/txrep_helper_test.dart
@@ -147,6 +147,14 @@ void main() {
       expect(TxRepHelper.escapeString('a\nb'), r'"a\nb"');
     });
 
+    test('escapes carriage return as \\r', () {
+      expect(TxRepHelper.escapeString('a\rb'), r'"a\rb"');
+    });
+
+    test('escapes tab as \\t', () {
+      expect(TxRepHelper.escapeString('a\tb'), r'"a\tb"');
+    });
+
     test('escapes non-ASCII bytes as \\xNN', () {
       // \u00FF (ÿ) is 0xC3 0xBF in UTF-8
       var result = TxRepHelper.escapeString('\u00FF');
@@ -177,6 +185,14 @@ void main() {
 
     test('unescapes newline', () {
       expect(TxRepHelper.unescapeString(r'"a\nb"'), 'a\nb');
+    });
+
+    test('unescapes carriage return', () {
+      expect(TxRepHelper.unescapeString(r'"a\rb"'), 'a\rb');
+    });
+
+    test('unescapes tab', () {
+      expect(TxRepHelper.unescapeString(r'"a\tb"'), 'a\tb');
     });
 
     test('unescapes hex sequences', () {


### PR DESCRIPTION
### Summary

Bug fix. The SEP-0011 facade encoded `MEMO_TEXT` via `jsonEncode`, producing `\uNNNN` Unicode escapes for non-ASCII characters. [SEP-0011](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0011.md) specifies C-style `\xNN` UTF-8 byte escapes (e.g. `"caf\xc3\xa9"` rather than `"caf\u00e9"`), so output from this SDK could fail to parse in strict implementations.

### Backwards compatibility

Encoded output for non-ASCII `MEMO_TEXT` changes byte-for-byte; consumers comparing TxRep strings or using golden files will see diffs. Decoding remains compatible with legacy `\uNNNN` output from older SDK versions.

### Changes

- `lib/src/sep/0011/txrep.dart`: `_encodeMemo` now delegates to `TxRepHelper.escapeString`. `_decodeMemo` tries `unescapeString` first and falls back to `jsonDecode` only when an unescaped `\uNNNN` sequence is detected (via lookbehind regex), so legacy TxRep blobs from older SDK versions still parse. Both decode paths wrap `FormatException` as a TxRep-style `Exception`.
- `lib/src/xdr/txrep_helper.dart`: `escapeString` now emits `\r` and `\t` as C-style short escapes; `unescapeString` decodes them.
- Tests: non-ASCII encode, legacy `\uNNNN` decode, newline, 4-byte UTF-8 (emoji), empty string, literal backslash-u (heuristic edge case), 28-byte UTF-8 boundary, legacy decode with embedded quote escapes, and `\r` / `\t` round-trips at the helper level.