### PR TITLE
Reject SEP-10 challenges without finite time bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Add headless `connectToContract` to connect an OpenZeppelin smart account by its contract address alone, with no passkey credential, for autonomous signing processes and backend services that operate through the multi-signer / external-signer path. Adds `OZConnectToContractResult`, the `OZSmartAccountEventHeadlessConnected` event, and the `OZSmartAccountKit.isHeadless` / `OZConnectedState.isHeadless` getters.
 - `OZConnectedState.credentialId` is now nullable (`String?`); a `null` value indicates a headless connection. This is a minor breaking change for code that reads `credentialId` as a non-null `String`.
 - Poll the Soroban RPC for funding-account and contract-instance visibility instead of waiting a fixed delay, improving the reliability of wallet creation and contract connection.
+- Reject SEP-10 challenge transactions that have no time bounds or an infinite maximum time, as required by the spec.
 
 ## [3.2.0] - 19.Jun.2026.
 - Add Protocol 27 (CAP-71) Soroban authorization support: the ADDRESS_V2 and ADDRESS_WITH_DELEGATES credential arms with delegated account authorization

--- a/lib/src/sep/0010/webauth.dart
+++ b/lib/src/sep/0010/webauth.dart
@@ -547,21 +547,31 @@ class WebAuth {
       }
     }
 
-    // check timebounds
-    final timeBounds = transaction.cond.timeBounds;
-    if (timeBounds != null) {
-      int grace = 0;
-      if (timeBoundsGracePeriod != null) {
-        grace = timeBoundsGracePeriod;
-      }
-      final currentTime = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-      final minTime = timeBounds.minTime.uint64.toInt();
-      final maxTime = timeBounds.maxTime.uint64.toInt();
-      if (currentTime < minTime - grace ||
-          currentTime > maxTime + grace) {
-        throw ChallengeValidationErrorInvalidTimeBounds(
-            "Invalid transaction, invalid time bounds");
-      }
+    // check timebounds: a challenge with no time bounds, or with an infinite
+    // (zero) max time, is never time-limited and could be replayed
+    // indefinitely, so reject it instead of skipping the check. Resolving the
+    // preconditions yields the bounds whether they are carried as a v1 time
+    // precondition or inside a v2 precondition.
+    final timeBounds =
+        TransactionPreconditions.fromXdr(transaction.cond).timeBounds;
+    if (timeBounds == null) {
+      throw ChallengeValidationErrorInvalidTimeBounds(
+          "Invalid transaction, missing time bounds");
+    }
+    int grace = 0;
+    if (timeBoundsGracePeriod != null) {
+      grace = timeBoundsGracePeriod;
+    }
+    final currentTime = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final minTime = timeBounds.minTime;
+    final maxTime = timeBounds.maxTime;
+    if (maxTime == 0) {
+      throw ChallengeValidationErrorInvalidTimeBounds(
+          "Invalid transaction, requires non-infinite time bounds");
+    }
+    if (currentTime < minTime - grace || currentTime > maxTime + grace) {
+      throw ChallengeValidationErrorInvalidTimeBounds(
+          "Invalid transaction, invalid time bounds");
     }
 
     // the envelope must have one signature and it must be valid: transaction signed by the server

--- a/test/unit/sep/webauth_test.dart
+++ b/test/unit/sep/webauth_test.dart
@@ -47,6 +47,8 @@ void main() {
       int? memo,
       bool includeWebAuthDomain = true,
       TimeBounds? timeBounds,
+      bool includeTimeBounds = true,
+      bool useV2Preconditions = false,
       String? clientDomainAccountId,
     }) {
       final actualClientAccountId = clientAccountId ?? clientKeyPair.accountId;
@@ -87,11 +89,22 @@ void main() {
         txBuilder.addOperation(op);
       }
 
-      if (timeBounds != null) {
-        txBuilder.addTimeBounds(timeBounds);
-      } else {
-        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-        txBuilder.addTimeBounds(TimeBounds(now, now + 300));
+      if (useV2Preconditions) {
+        // minSeqAge forces a PRECOND_V2 envelope so the time bounds are
+        // carried inside cond.v2.timeBounds rather than cond.timeBounds.
+        final preconditions = TransactionPreconditions()..minSeqAge = 1;
+        if (includeTimeBounds) {
+          final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+          preconditions.timeBounds = timeBounds ?? TimeBounds(now, now + 300);
+        }
+        txBuilder.addPreconditions(preconditions);
+      } else if (includeTimeBounds) {
+        if (timeBounds != null) {
+          txBuilder.addTimeBounds(timeBounds);
+        } else {
+          final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+          txBuilder.addTimeBounds(TimeBounds(now, now + 300));
+        }
       }
 
       if (memo != null) {
@@ -168,6 +181,117 @@ void main() {
             200,
           ),
           returnsNormally,
+        );
+      });
+    });
+
+    group('validateChallenge - Time Bounds', () {
+      test('throws when the challenge has no time bounds', () {
+        final challenge = buildValidChallenge(includeTimeBounds: false);
+
+        expect(
+          () => webAuth.validateChallenge(
+            challenge,
+            clientKeyPair.accountId,
+            null,
+          ),
+          throwsA(isA<ChallengeValidationErrorInvalidTimeBounds>().having(
+            (e) => e.toString(),
+            'message',
+            contains('missing time bounds'),
+          )),
+        );
+      });
+
+      test('throws when the challenge has an infinite (zero) max time', () {
+        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+        final challenge = buildValidChallenge(timeBounds: TimeBounds(now, 0));
+
+        expect(
+          () => webAuth.validateChallenge(
+            challenge,
+            clientKeyPair.accountId,
+            null,
+          ),
+          throwsA(isA<ChallengeValidationErrorInvalidTimeBounds>().having(
+            (e) => e.toString(),
+            'message',
+            contains('non-infinite time bounds'),
+          )),
+        );
+      });
+
+      test('throws when the challenge is expired beyond the grace period', () {
+        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+        final challenge = buildValidChallenge(
+          timeBounds: TimeBounds(now - 1000, now - 500),
+        );
+
+        expect(
+          () => webAuth.validateChallenge(
+            challenge,
+            clientKeyPair.accountId,
+            null,
+          ),
+          throwsA(isA<ChallengeValidationErrorInvalidTimeBounds>().having(
+            (e) => e.toString(),
+            'message',
+            contains('invalid time bounds'),
+          )),
+        );
+      });
+
+      test('accepts a v2-precondition challenge with valid time bounds', () {
+        final challenge = buildValidChallenge(useV2Preconditions: true);
+
+        expect(
+          () => webAuth.validateChallenge(
+            challenge,
+            clientKeyPair.accountId,
+            null,
+          ),
+          returnsNormally,
+        );
+      });
+
+      test('throws for a v2-precondition challenge with infinite max time', () {
+        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+        final challenge = buildValidChallenge(
+          useV2Preconditions: true,
+          timeBounds: TimeBounds(now, 0),
+        );
+
+        expect(
+          () => webAuth.validateChallenge(
+            challenge,
+            clientKeyPair.accountId,
+            null,
+          ),
+          throwsA(isA<ChallengeValidationErrorInvalidTimeBounds>().having(
+            (e) => e.toString(),
+            'message',
+            contains('non-infinite time bounds'),
+          )),
+        );
+      });
+
+      test('throws for a v2-precondition challenge with no time bounds', () {
+        final challenge = buildValidChallenge(
+          useV2Preconditions: true,
+          includeTimeBounds: false,
+        );
+
+        expect(
+          () => webAuth.validateChallenge(
+            challenge,
+            clientKeyPair.accountId,
+            null,
+          ),
+          throwsA(isA<ChallengeValidationErrorInvalidTimeBounds>().having(
+            (e) => e.toString(),
+            'message',
+            contains('missing time bounds'),
+          )),
         );
       });
     });


### PR DESCRIPTION
## Summary

`WebAuth.validateChallenge` skipped time-bounds validation when a challenge transaction carried no time bounds, so such a challenge was accepted. SEP-10 requires challenge transactions to be time-bounded; challenges with no time bounds, or with an infinite maximum time (`maxTime == 0`), are now rejected.
