### PR TITLE
Add XdrSCVal.toNative()

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,8 @@ jobs:
             test/unit/sep/sep51_stellar_types_test.dart \
             test/unit/xdr/json_generated/ \
             test/unit/xdr/xdr_json_helper_test.dart \
-            test/unit/xdr/xdr_json_reference_rendering_test.dart
+            test/unit/xdr/xdr_json_reference_rendering_test.dart \
+            test/unit/xdr/xdr_sc_val_to_native_test.dart
 
       # `flutter test` has no WasmGC platform, so the nesting guard is checked there by
       # compiling a harness and running it under Node. A guard that let an over-nested

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Unreleased]
+- `XdrSCVal` gains `toNative()`, converting a smart contract value to native Dart values on a best-effort basis: `BigInt` for every 64-bit-and-wider integer, `Address` for address values, and `List`/`Map` for vecs and maps. A value with no faithful native representation, or a map with an unrepresentable or colliding key, converts to the `XdrSCVal` itself so a caller can detect the fallback with `is XdrSCVal`. The method is opt-in and never throws; no existing API changes behavior.
+
 ## [3.6.0] - 25.Aug.2026.
 - Migration guide for existing code: [documentation/migration/3.6.0.md](documentation/migration/3.6.0.md).
 - Breaking change: strkey decoding and keypair construction reject a number of inputs they used to accept. Every case is listed below; code that decodes addresses coming from users or from the network is worth checking against it.

--- a/lib/src/xdr/xdr_sc_val.dart
+++ b/lib/src/xdr/xdr_sc_val.dart
@@ -8,6 +8,7 @@ import 'dart:typed_data';
 import 'package:stellar_flutter_sdk/src/constants/bit_constants.dart';
 import 'package:stellar_flutter_sdk/src/key_pair.dart';
 import 'package:stellar_flutter_sdk/src/soroban/soroban_auth.dart';
+import 'package:stellar_flutter_sdk/src/util.dart';
 
 import 'xdr_data_io.dart';
 import 'xdr_json_helper.dart';
@@ -665,6 +666,214 @@ class XdrSCVal extends XdrSCValBase {
         break;
     }
     return null;
+  }
+
+  /// Converts this value to a native Dart value on a best-effort basis.
+  ///
+  /// Every 64-bit-and-wider integer arm (SCV_U64, SCV_I64, SCV_TIMEPOINT,
+  /// SCV_DURATION, SCV_U128, SCV_I128, SCV_U256 and SCV_I256) converts to
+  /// BigInt rather than int, so the value is exact on every platform this
+  /// SDK targets, including Flutter web. SCV_ADDRESS converts to an
+  /// [Address]. SCV_MAP converts to a Map whose keys use a narrower
+  /// conversion than values: a bytes key becomes a lowercase hex String and
+  /// an address key becomes its StrKey String, because Uint8List and
+  /// Address have no value equality and so cannot serve as usable map
+  /// keys. A Dart int key and a BigInt key holding the same numeric value
+  /// are distinct map entries. This method never throws: an arm with no
+  /// native representation, an ill-formed payload, or a map with an
+  /// unrepresentable or colliding key converts to this XdrSCVal itself,
+  /// which a caller can detect with `is XdrSCVal`. The Uint8List returned
+  /// for SCV_BYTES is the stored instance, not a copy.
+  dynamic toNative() {
+    switch (discriminant) {
+      case XdrSCValType.SCV_BOOL:
+        if (b != null) {
+          return b!;
+        }
+        break;
+      case XdrSCValType.SCV_VOID:
+        return null;
+      case XdrSCValType.SCV_U32:
+        if (u32 != null) {
+          return u32!.uint32;
+        }
+        break;
+      case XdrSCValType.SCV_I32:
+        if (i32 != null) {
+          return i32!.int32;
+        }
+        break;
+      case XdrSCValType.SCV_U64:
+        if (u64 != null) {
+          return u64!.uint64;
+        }
+        break;
+      case XdrSCValType.SCV_I64:
+        if (i64 != null) {
+          return i64!.int64;
+        }
+        break;
+      case XdrSCValType.SCV_TIMEPOINT:
+        if (timepoint != null) {
+          return timepoint!.uint64;
+        }
+        break;
+      case XdrSCValType.SCV_DURATION:
+        if (duration != null) {
+          return duration!.uint64;
+        }
+        break;
+      case XdrSCValType.SCV_U128:
+      case XdrSCValType.SCV_I128:
+      case XdrSCValType.SCV_U256:
+      case XdrSCValType.SCV_I256:
+        final BigInt? value = toBigInt();
+        if (value != null) {
+          return value;
+        }
+        break;
+      case XdrSCValType.SCV_BYTES:
+        if (bytes != null) {
+          return bytes!.sCBytes;
+        }
+        break;
+      case XdrSCValType.SCV_STRING:
+        if (str != null) {
+          return str!;
+        }
+        break;
+      case XdrSCValType.SCV_SYMBOL:
+        if (sym != null) {
+          return sym!;
+        }
+        break;
+      case XdrSCValType.SCV_VEC:
+        return (vec ?? const <XdrSCVal>[])
+            .map((XdrSCVal e) => e.toNative())
+            .toList();
+      case XdrSCValType.SCV_MAP:
+        return _mapToNative();
+      case XdrSCValType.SCV_ADDRESS:
+        if (address != null) {
+          try {
+            return Address.fromXdr(address!);
+          } catch (_) {
+            return this;
+          }
+        }
+        break;
+    }
+    return this;
+  }
+
+  /// Converts this SCV_MAP value's entries to a native Dart Map.
+  ///
+  /// A null [map] payload converts to an empty Map. The whole map falls
+  /// back to this XdrSCVal itself when a key is unrepresentable (per
+  /// [_mapKeyToNative]) or when two entries collide on the same Dart key,
+  /// detected by comparing the entry count with the resulting Map's
+  /// length.
+  dynamic _mapToNative() {
+    final List<XdrSCMapEntry>? entries = map;
+    if (entries == null) {
+      return <dynamic, dynamic>{};
+    }
+    final Map<dynamic, dynamic> result = <dynamic, dynamic>{};
+    for (final XdrSCMapEntry entry in entries) {
+      final Object? key = _mapKeyToNative(entry.key);
+      if (identical(key, _unrepresentableKey)) {
+        return this;
+      }
+      result[key] = entry.val.toNative();
+    }
+    if (result.length != entries.length) {
+      return this;
+    }
+    return result;
+  }
+
+  /// Sentinel returned by [_mapKeyToNative] for a key with no usable native
+  /// map-key representation. `null` is a legitimate key result (the
+  /// SCV_VOID key), so the sentinel is checked by identity, not equality.
+  static final Object _unrepresentableKey = Object();
+
+  /// Converts [key] to a native Dart map key, or [_unrepresentableKey] when
+  /// [key]'s arm, or an ill-formed payload, has no usable native map-key
+  /// representation.
+  static Object? _mapKeyToNative(XdrSCVal key) {
+    switch (key.discriminant) {
+      case XdrSCValType.SCV_SYMBOL:
+        if (key.sym != null) {
+          return key.sym!;
+        }
+        break;
+      case XdrSCValType.SCV_STRING:
+        if (key.str != null) {
+          return key.str!;
+        }
+        break;
+      case XdrSCValType.SCV_U32:
+        if (key.u32 != null) {
+          return key.u32!.uint32;
+        }
+        break;
+      case XdrSCValType.SCV_I32:
+        if (key.i32 != null) {
+          return key.i32!.int32;
+        }
+        break;
+      case XdrSCValType.SCV_U64:
+        if (key.u64 != null) {
+          return key.u64!.uint64;
+        }
+        break;
+      case XdrSCValType.SCV_I64:
+        if (key.i64 != null) {
+          return key.i64!.int64;
+        }
+        break;
+      case XdrSCValType.SCV_TIMEPOINT:
+        if (key.timepoint != null) {
+          return key.timepoint!.uint64;
+        }
+        break;
+      case XdrSCValType.SCV_DURATION:
+        if (key.duration != null) {
+          return key.duration!.uint64;
+        }
+        break;
+      case XdrSCValType.SCV_U128:
+      case XdrSCValType.SCV_I128:
+      case XdrSCValType.SCV_U256:
+      case XdrSCValType.SCV_I256:
+        final BigInt? value = key.toBigInt();
+        if (value != null) {
+          return value;
+        }
+        break;
+      case XdrSCValType.SCV_BOOL:
+        if (key.b != null) {
+          return key.b!;
+        }
+        break;
+      case XdrSCValType.SCV_VOID:
+        return null;
+      case XdrSCValType.SCV_BYTES:
+        if (key.bytes != null) {
+          return Util.bytesToHex(key.bytes!.sCBytes);
+        }
+        break;
+      case XdrSCValType.SCV_ADDRESS:
+        if (key.address != null) {
+          try {
+            return key.address!.toStrKey();
+          } catch (_) {
+            return _unrepresentableKey;
+          }
+        }
+        break;
+    }
+    return _unrepresentableKey;
   }
 
   static XdrSCVal fromBase64EncodedXdrString(String base64Encoded) {

--- a/test/docsTest/soroban_test.dart
+++ b/test/docsTest/soroban_test.dart
@@ -668,4 +668,50 @@ void main() {
       expect(wasmHash, isNotNull);
     });
   });
+
+  group('toNative conversion (offline)', () {
+    test('soroban: toNative - Scalars and BigInt', () {
+      // Snippet from soroban.md "Converting to Native Dart Values"
+      XdrSCVal boolVal = XdrSCVal.forBool(true);
+      expect(boolVal.toNative(), true);
+
+      XdrSCVal u32Val = XdrSCVal.forU32(42);
+      expect(u32Val.toNative(), 42);
+
+      // u64 and wider integers always convert to BigInt, never int, so the
+      // value stays exact on every platform this SDK targets, web included.
+      XdrSCVal u64Val = XdrSCVal.forU64(BigInt.parse('18446744073709551615'));
+      dynamic nativeU64 = u64Val.toNative();
+      expect(nativeU64, isA<BigInt>());
+      expect(nativeU64, BigInt.parse('18446744073709551615'));
+    });
+
+    test('soroban: toNative - Maps preserve key order', () {
+      // Snippet from soroban.md "Converting to Native Dart Values"
+      XdrSCVal mapVal = XdrSCVal.forMap([
+        XdrSCMapEntry(
+            XdrSCVal.forSymbol('name'), XdrSCVal.forString('Alice')),
+        XdrSCMapEntry(XdrSCVal.forSymbol('age'), XdrSCVal.forU32(30)),
+      ]);
+
+      Map<dynamic, dynamic> native =
+          mapVal.toNative() as Map<dynamic, dynamic>;
+      expect(native, equals({'name': 'Alice', 'age': 30}));
+      expect(native.keys.toList(), equals(['name', 'age']));
+    });
+
+    test('soroban: toNative - Detecting a fallback', () {
+      // Snippet from soroban.md "Converting to Native Dart Values"
+      // A vec has no value equality, so it cannot serve as a map key: the
+      // whole map falls back to the XdrSCVal itself.
+      XdrSCVal mapWithVecKey = XdrSCVal.forMap([
+        XdrSCMapEntry(
+            XdrSCVal.forVec([XdrSCVal.forBool(true)]), XdrSCVal.forU32(1)),
+      ]);
+
+      dynamic native = mapWithVecKey.toNative();
+      expect(native is XdrSCVal, true);
+      expect(native, same(mapWithVecKey));
+    });
+  });
 }

--- a/test/unit/xdr/xdr_sc_val_to_native_test.dart
+++ b/test/unit/xdr/xdr_sc_val_to_native_test.dart
@@ -1,0 +1,550 @@
+// Tests for XdrSCVal.toNative(), the best-effort conversion of a smart
+// contract value to native Dart values. Every arm of the conversion contract
+// is pinned here: the per-type conversions, the BigInt rules for every
+// 64-bit-and-wider integer, the map key rules including the sentinel
+// design, both map fallback triggers, null-payload handling for every arm
+// that can carry one, and totality for ill-formed payloads that only
+// direct construction (never decode()) can produce.
+
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stellar_flutter_sdk/stellar_flutter_sdk.dart';
+
+void main() {
+  group('scalars', () {
+    test('bool converts to bool', () {
+      expect(XdrSCVal.forBool(true).toNative(), true);
+      expect(XdrSCVal.forBool(false).toNative(), false);
+    });
+
+    test('void converts to null', () {
+      expect(XdrSCVal.forVoid().toNative(), isNull);
+    });
+
+    test('u32 converts to int', () {
+      expect(XdrSCVal.forU32(0).toNative(), 0);
+      expect(XdrSCVal.forU32(4294967295).toNative(), 4294967295);
+    });
+
+    test('i32 converts to int', () {
+      expect(XdrSCVal.forI32(-2147483648).toNative(), -2147483648);
+      expect(XdrSCVal.forI32(2147483647).toNative(), 2147483647);
+    });
+
+    test('u64 converts to BigInt, never int', () {
+      final zero = XdrSCVal.forU64(BigInt.zero).toNative();
+      expect(zero, isA<BigInt>());
+      expect(zero, BigInt.zero);
+
+      final max = XdrSCVal.forU64(
+        BigInt.parse('18446744073709551615'),
+      ).toNative();
+      expect(max, isA<BigInt>());
+      expect(max, BigInt.parse('18446744073709551615'));
+    });
+
+    test('i64 converts to BigInt, never int', () {
+      final min = XdrSCVal.forI64(
+        BigInt.parse('-9223372036854775808'),
+      ).toNative();
+      expect(min, isA<BigInt>());
+      expect(min, BigInt.parse('-9223372036854775808'));
+
+      final max = XdrSCVal.forI64(
+        BigInt.parse('9223372036854775807'),
+      ).toNative();
+      expect(max, isA<BigInt>());
+      expect(max, BigInt.parse('9223372036854775807'));
+    });
+
+    test('timepoint and duration convert to BigInt, never int', () {
+      final timepoint = XdrSCVal.forTimepoint(
+        BigInt.parse('1700000000'),
+      ).toNative();
+      expect(timepoint, isA<BigInt>());
+      expect(timepoint, BigInt.parse('1700000000'));
+
+      final duration = XdrSCVal.forDuration(
+        BigInt.parse('18446744073709551615'),
+      ).toNative();
+      expect(duration, isA<BigInt>());
+      expect(duration, BigInt.parse('18446744073709551615'));
+    });
+  });
+
+  group('128-bit and 256-bit integers', () {
+    test('u128 converts to BigInt at its extreme (2^128-1)', () {
+      final result = XdrSCVal.forU128BigInt(
+        BigInt.parse('340282366920938463463374607431768211455'),
+      ).toNative();
+      expect(result, isA<BigInt>());
+      expect(result, BigInt.parse('340282366920938463463374607431768211455'));
+    });
+
+    test('i128 converts to BigInt at its extremes (-2^127 and -1)', () {
+      final min = XdrSCVal.forI128BigInt(
+        BigInt.parse('-170141183460469231731687303715884105728'),
+      ).toNative();
+      expect(min, isA<BigInt>());
+      expect(min, BigInt.parse('-170141183460469231731687303715884105728'));
+
+      final negativeOne = XdrSCVal.forI128BigInt(BigInt.from(-1)).toNative();
+      expect(negativeOne, BigInt.from(-1));
+    });
+
+    test('u256 converts to BigInt at its extreme (2^256-1)', () {
+      final result = XdrSCVal.forU256BigInt(
+        BigInt.parse(
+          '115792089237316195423570985008687907853269984665640564039457584007913129639935',
+        ),
+      ).toNative();
+      expect(result, isA<BigInt>());
+      expect(
+        result,
+        BigInt.parse(
+          '115792089237316195423570985008687907853269984665640564039457584007913129639935',
+        ),
+      );
+    });
+
+    test('i256 converts to BigInt at its extreme (-2^255)', () {
+      final result = XdrSCVal.forI256BigInt(
+        BigInt.parse(
+          '-57896044618658097711785492504343953926634992332820282019728792003956564819968',
+        ),
+      ).toNative();
+      expect(result, isA<BigInt>());
+      expect(
+        result,
+        BigInt.parse(
+          '-57896044618658097711785492504343953926634992332820282019728792003956564819968',
+        ),
+      );
+    });
+  });
+
+  group('bytes, strings and symbols', () {
+    test('bytes converts to the stored Uint8List instance', () {
+      final bytes = Uint8List.fromList([0, 1, 255]);
+      final val = XdrSCVal.forBytes(bytes);
+      final result = val.toNative();
+      expect(result, isA<Uint8List>());
+      expect(result, equals(bytes));
+      expect(identical(result, val.bytes!.sCBytes), isTrue);
+    });
+
+    test('string converts to String, including multi-byte UTF-8', () {
+      expect(XdrSCVal.forString('hello').toNative(), 'hello');
+      expect(XdrSCVal.forString('héllo €𝕏').toNative(), 'héllo €𝕏');
+    });
+
+    test('symbol converts to String', () {
+      expect(XdrSCVal.forSymbol('transfer').toNative(), 'transfer');
+    });
+  });
+
+  group('vec', () {
+    test('a vec converts to a List, elements converted recursively', () {
+      final val = XdrSCVal.forVec([
+        XdrSCVal.forU32(1),
+        XdrSCVal.forSymbol('a'),
+        XdrSCVal.forVec([XdrSCVal.forBool(true)]),
+      ]);
+      expect(
+        val.toNative(),
+        equals([
+          1,
+          'a',
+          [true],
+        ]),
+      );
+    });
+
+    test('an empty vec converts to an empty List', () {
+      expect(XdrSCVal.forVec([]).toNative(), equals([]));
+    });
+
+    test('a vec with a null payload converts to an empty List', () {
+      final val = XdrSCVal(XdrSCValType.SCV_VEC);
+      expect(val.vec, isNull);
+      expect(val.toNative(), equals([]));
+    });
+
+    test('a vec containing a fallback map keeps that map as an element', () {
+      final mapWithVecKey = XdrSCVal.forMap([
+        XdrSCMapEntry(
+          XdrSCVal.forVec([XdrSCVal.forBool(true)]),
+          XdrSCVal.forU32(1),
+        ),
+      ]);
+      final val = XdrSCVal.forVec([XdrSCVal.forU32(7), mapWithVecKey]);
+      final result = val.toNative() as List<dynamic>;
+      expect(result[0], 7);
+      expect(result[1], same(mapWithVecKey));
+    });
+  });
+
+  group('map', () {
+    test('symbol keys convert to a Map preserving insertion order', () {
+      final val = XdrSCVal.forMap([
+        XdrSCMapEntry(XdrSCVal.forSymbol('name'), XdrSCVal.forString('Alice')),
+        XdrSCMapEntry(XdrSCVal.forSymbol('age'), XdrSCVal.forU32(30)),
+      ]);
+      final result = val.toNative() as Map<dynamic, dynamic>;
+      expect(result, equals({'name': 'Alice', 'age': 30}));
+      expect(result.keys.toList(), equals(['name', 'age']));
+    });
+
+    test('u32 keys convert to int keys', () {
+      final val = XdrSCVal.forMap([
+        XdrSCMapEntry(XdrSCVal.forU32(1), XdrSCVal.forString('one')),
+        XdrSCMapEntry(XdrSCVal.forU32(2), XdrSCVal.forString('two')),
+      ]);
+      final result = val.toNative() as Map<dynamic, dynamic>;
+      expect(result, equals({1: 'one', 2: 'two'}));
+      expect(result.keys.toList(), equals([1, 2]));
+    });
+
+    test('a string key converts to a String key', () {
+      final val = XdrSCVal.forMap([
+        XdrSCMapEntry(XdrSCVal.forString('label'), XdrSCVal.forU32(1)),
+      ]);
+      final result = val.toNative() as Map<dynamic, dynamic>;
+      expect(result.keys.toList(), equals(['label']));
+    });
+
+    test('an i32 key converts to an int key', () {
+      final val = XdrSCVal.forMap([
+        XdrSCMapEntry(XdrSCVal.forI32(-7), XdrSCVal.forU32(1)),
+      ]);
+      final result = val.toNative() as Map<dynamic, dynamic>;
+      expect(result.keys.toList(), equals([-7]));
+    });
+
+    test('a timepoint key converts to a BigInt key', () {
+      final key = BigInt.parse('1700000000');
+      final val = XdrSCVal.forMap([
+        XdrSCMapEntry(XdrSCVal.forTimepoint(key), XdrSCVal.forU32(1)),
+      ]);
+      final result = val.toNative() as Map<dynamic, dynamic>;
+      expect(result.keys.toList(), equals([key]));
+    });
+
+    test('a duration key converts to a BigInt key', () {
+      final key = BigInt.parse('18446744073709551615');
+      final val = XdrSCVal.forMap([
+        XdrSCMapEntry(XdrSCVal.forDuration(key), XdrSCVal.forU32(1)),
+      ]);
+      final result = val.toNative() as Map<dynamic, dynamic>;
+      expect(result.keys.toList(), equals([key]));
+    });
+
+    test('an i64 key converts to a BigInt key', () {
+      final val = XdrSCVal.forMap([
+        XdrSCMapEntry(
+          XdrSCVal.forI64(BigInt.from(-5)),
+          XdrSCVal.forString('negative five'),
+        ),
+      ]);
+      final result = val.toNative() as Map<dynamic, dynamic>;
+      expect(result.keys.toList(), equals([BigInt.from(-5)]));
+    });
+
+    test('a u64 key at its extreme converts to that BigInt key', () {
+      final key = BigInt.parse('18446744073709551615');
+      final val = XdrSCVal.forMap([
+        XdrSCMapEntry(XdrSCVal.forU64(key), XdrSCVal.forString('max u64')),
+      ]);
+      final result = val.toNative() as Map<dynamic, dynamic>;
+      expect(result.keys.toList(), equals([key]));
+    });
+
+    test('an i128 key converts to its BigInt via toBigInt()', () {
+      final key = BigInt.parse('170141183460469231731687303715884105727');
+      final val = XdrSCVal.forMap([
+        XdrSCMapEntry(
+          XdrSCVal.forI128BigInt(key),
+          XdrSCVal.forString('max i128'),
+        ),
+      ]);
+      final result = val.toNative() as Map<dynamic, dynamic>;
+      expect(result.keys.toList(), equals([key]));
+    });
+
+    test('a bool key converts to a bool key and a void key to null', () {
+      final val = XdrSCVal.forMap([
+        XdrSCMapEntry(XdrSCVal.forBool(true), XdrSCVal.forU32(1)),
+        XdrSCMapEntry(XdrSCVal.forVoid(), XdrSCVal.forU32(2)),
+      ]);
+      final result = val.toNative() as Map<dynamic, dynamic>;
+      expect(result.keys.toList(), equals([true, null]));
+      expect(result[true], 1);
+      expect(result[null], 2);
+    });
+
+    test('a bytes key converts to a lowercase hex String key', () {
+      final val = XdrSCVal.forMap([
+        XdrSCMapEntry(
+          XdrSCVal.forBytes(Uint8List.fromList([1, 2])),
+          XdrSCVal.forU32(1),
+        ),
+      ]);
+      final result = val.toNative() as Map<dynamic, dynamic>;
+      expect(result.keys.toList(), equals(['0102']));
+    });
+
+    test('an account address key converts to its StrKey String', () {
+      const g = 'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB';
+      final val = XdrSCVal.forMap([
+        XdrSCMapEntry(XdrSCVal.forAccountAddress(g), XdrSCVal.forU32(1)),
+      ]);
+      final result = val.toNative() as Map<dynamic, dynamic>;
+      expect(result.keys.toList(), equals([g]));
+    });
+
+    test('a contract address key converts to its StrKey String', () {
+      const c = 'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE';
+      final val = XdrSCVal.forMap([
+        XdrSCMapEntry(XdrSCVal.forContractAddress(c), XdrSCVal.forU32(1)),
+      ]);
+      final result = val.toNative() as Map<dynamic, dynamic>;
+      expect(result.keys.toList(), equals([c]));
+    });
+
+    test('a u32 key and a u64 key holding the same number are distinct', () {
+      final val = XdrSCVal.forMap([
+        XdrSCMapEntry(XdrSCVal.forU32(5), XdrSCVal.forString('u32 five')),
+        XdrSCMapEntry(
+          XdrSCVal.forU64(BigInt.from(5)),
+          XdrSCVal.forString('u64 five'),
+        ),
+      ]);
+      final result = val.toNative() as Map<dynamic, dynamic>;
+      expect(result.length, 2);
+      expect(result.keys.toList(), equals([5, BigInt.from(5)]));
+    });
+
+    test('a vec key makes the whole map fall back to itself', () {
+      final val = XdrSCVal.forMap([
+        XdrSCMapEntry(
+          XdrSCVal.forVec([XdrSCVal.forU32(1)]),
+          XdrSCVal.forU32(1),
+        ),
+      ]);
+      expect(val.toNative(), same(val));
+    });
+
+    test('a map key makes the whole map fall back to itself', () {
+      final val = XdrSCVal.forMap([
+        XdrSCMapEntry(XdrSCVal.forMap([]), XdrSCVal.forU32(1)),
+      ]);
+      expect(val.toNative(), same(val));
+    });
+
+    test('an error key makes the whole map fall back to itself', () {
+      final error = XdrSCError(XdrSCErrorType.SCE_CONTRACT);
+      error.contractCode = XdrUint32(1);
+      final val = XdrSCVal.forMap([
+        XdrSCMapEntry(XdrSCVal.forError(error), XdrSCVal.forU32(1)),
+      ]);
+      expect(val.toNative(), same(val));
+    });
+
+    test(
+      'two entries colliding on the same key fall back to the map itself',
+      () {
+        final val = XdrSCVal.forMap([
+          XdrSCMapEntry(XdrSCVal.forSymbol('a'), XdrSCVal.forU32(1)),
+          XdrSCMapEntry(XdrSCVal.forSymbol('a'), XdrSCVal.forU32(2)),
+        ]);
+        expect(val.toNative(), same(val));
+      },
+    );
+
+    test(
+      'a u64 key and a u128 key holding the same value collide (equal BigInt)',
+      () {
+        final val = XdrSCVal.forMap([
+          XdrSCMapEntry(XdrSCVal.forU64(BigInt.from(7)), XdrSCVal.forU32(1)),
+          XdrSCMapEntry(
+            XdrSCVal.forU128BigInt(BigInt.from(7)),
+            XdrSCVal.forU32(2),
+          ),
+        ]);
+        expect(val.toNative(), same(val));
+      },
+    );
+
+    test('an empty map converts to an empty Map', () {
+      expect(XdrSCVal.forMap([]).toNative(), equals(<dynamic, dynamic>{}));
+    });
+
+    test('a map with a null payload converts to an empty Map', () {
+      final val = XdrSCVal(XdrSCValType.SCV_MAP);
+      expect(val.map, isNull);
+      expect(val.toNative(), equals(<dynamic, dynamic>{}));
+    });
+  });
+
+  group('address values', () {
+    test('an account address value converts to an Address', () {
+      const g = 'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB';
+      final native = XdrSCVal.forAccountAddress(g).toNative();
+      expect(native, isA<Address>());
+      final address = native as Address;
+      expect(address.type, Address.TYPE_ACCOUNT);
+      expect(address.accountId, g);
+    });
+
+    test('a contract address value converts to an Address', () {
+      const c = 'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE';
+      final val = XdrSCVal.forContractAddress(c);
+      final native = val.toNative();
+      expect(native, isA<Address>());
+      final address = native as Address;
+      expect(address.type, Address.TYPE_CONTRACT);
+      expect(val.address!.toStrKey(), c);
+    });
+  });
+
+  group('fallback arms returning the value itself', () {
+    test('an error value falls back to itself', () {
+      final error = XdrSCError(XdrSCErrorType.SCE_CONTRACT);
+      error.contractCode = XdrUint32(1);
+      final val = XdrSCVal.forError(error);
+      expect(val.toNative(), same(val));
+    });
+
+    test('a contract instance value falls back to itself', () {
+      final val = XdrSCVal.forContractInstance(
+        XdrSCContractInstance(
+          XdrContractExecutable.forWasm(Uint8List(32)),
+          null,
+        ),
+      );
+      expect(val.toNative(), same(val));
+    });
+
+    test('a ledger-key-contract-instance value falls back to itself', () {
+      final val = XdrSCVal.forLedgerKeyContractInstance();
+      expect(val.toNative(), same(val));
+    });
+
+    test('a ledger-key-nonce value falls back to itself', () {
+      final val = XdrSCVal.forLedgerKeyNonce(1);
+      expect(val.toNative(), same(val));
+    });
+
+    test('an executable tag value falls back to itself', () {
+      final val = XdrSCVal.forExecutableTag('token-v1');
+      expect(val.toNative(), same(val));
+    });
+
+    test('an unrecognized future arm falls back to itself', () {
+      final val = XdrSCVal(XdrSCValType(99));
+      expect(val.toNative(), same(val));
+    });
+
+    test('an unrecognized future arm as a map key falls back the map', () {
+      final val = XdrSCVal.forMap([
+        XdrSCMapEntry(XdrSCVal(XdrSCValType(99)), XdrSCVal.forU32(1)),
+      ]);
+      expect(val.toNative(), same(val));
+    });
+  });
+
+  group('ill-formed payloads return the value itself (toNative)', () {
+    test('every null-payload arm falls back to the same instance', () {
+      final illFormed = <XdrSCVal>[
+        XdrSCVal(XdrSCValType.SCV_BOOL),
+        XdrSCVal(XdrSCValType.SCV_U32),
+        XdrSCVal(XdrSCValType.SCV_I32),
+        XdrSCVal(XdrSCValType.SCV_U64),
+        XdrSCVal(XdrSCValType.SCV_I64),
+        XdrSCVal(XdrSCValType.SCV_TIMEPOINT),
+        XdrSCVal(XdrSCValType.SCV_DURATION),
+        XdrSCVal(XdrSCValType.SCV_U128),
+        XdrSCVal(XdrSCValType.SCV_BYTES),
+        XdrSCVal(XdrSCValType.SCV_STRING),
+        XdrSCVal(XdrSCValType.SCV_SYMBOL),
+        XdrSCVal(XdrSCValType.SCV_ADDRESS),
+      ];
+      for (final val in illFormed) {
+        expect(val.toNative(), same(val));
+      }
+    });
+
+    test(
+      'an ill-formed address value returns the value itself, no exception',
+      () {
+        final val = XdrSCVal.forAddress(
+          XdrSCAddress(XdrSCAddressType.SC_ADDRESS_TYPE_CONTRACT),
+        );
+        expect(val.address!.contractId, isNull);
+        expect(val.toNative(), same(val));
+      },
+    );
+  });
+
+  group('ill-formed map key payloads make the map fall back', () {
+    test('every null-payload key arm falls back the enclosing map', () {
+      final illFormedKeys = <XdrSCVal>[
+        XdrSCVal(XdrSCValType.SCV_SYMBOL),
+        XdrSCVal(XdrSCValType.SCV_STRING),
+        XdrSCVal(XdrSCValType.SCV_U32),
+        XdrSCVal(XdrSCValType.SCV_I32),
+        XdrSCVal(XdrSCValType.SCV_U64),
+        XdrSCVal(XdrSCValType.SCV_I64),
+        XdrSCVal(XdrSCValType.SCV_TIMEPOINT),
+        XdrSCVal(XdrSCValType.SCV_DURATION),
+        XdrSCVal(XdrSCValType.SCV_U128),
+        XdrSCVal(XdrSCValType.SCV_BOOL),
+        XdrSCVal(XdrSCValType.SCV_BYTES),
+        XdrSCVal(XdrSCValType.SCV_ADDRESS),
+      ];
+      for (final key in illFormedKeys) {
+        final mapVal = XdrSCVal.forMap([
+          XdrSCMapEntry(key, XdrSCVal.forU32(1)),
+        ]);
+        expect(mapVal.toNative(), same(mapVal));
+      }
+    });
+
+    test('an ill-formed address key falls back the enclosing map', () {
+      final key = XdrSCAddress(XdrSCAddressType.SC_ADDRESS_TYPE_CONTRACT);
+      final mapVal = XdrSCVal.forMap([
+        XdrSCMapEntry(XdrSCVal.forAddress(key), XdrSCVal.forU32(1)),
+      ]);
+      expect(key.contractId, isNull);
+      expect(mapVal.toNative(), same(mapVal));
+    });
+  });
+
+  group('round trip through wire format', () {
+    test('a decode()-produced tree converts identically to a factory-built '
+        'one', () {
+      final val = XdrSCVal.forMap([
+        XdrSCMapEntry(
+          XdrSCVal.forSymbol('items'),
+          XdrSCVal.forVec([
+            XdrSCVal.forU32(1),
+            XdrSCVal.forI128BigInt(
+              BigInt.parse('-170141183460469231731687303715884105728'),
+            ),
+          ]),
+        ),
+        XdrSCMapEntry(
+          XdrSCVal.forSymbol('big'),
+          XdrSCVal.forU64(BigInt.parse('18446744073709551615')),
+        ),
+      ]);
+
+      final decoded = XdrSCVal.fromBase64EncodedXdrString(
+        val.toBase64EncodedXdrString(),
+      );
+
+      expect(decoded.toNative(), equals(val.toNative()));
+    });
+  });
+}


### PR DESCRIPTION
`XdrSCVal` gains an opt-in `toNative()` method that converts a smart contract value to native Dart values: `BigInt` for 64-bit-and-wider integers, `String`, `Uint8List`, `Address`, lists, and maps. The conversion is best-effort and never throws; a value with no faithful native representation comes back as the `XdrSCVal` itself, and the caller decides how to proceed. Existing APIs are unchanged, and the full conversion semantics are documented on the method's doc comment.